### PR TITLE
lib.simpleOptions: playing around with

### DIFF
--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -407,19 +407,19 @@ lib.simpleOptions {
             ]);
           in
           { config, name, ... }:
-          {
+          lib.simpleOptions {
             options = {
-              from = mkOption {
+              from = {
                 type = referenceAttrs;
                 example = { type = "indirect"; id = "nixpkgs"; };
                 description = lib.mdDoc "The flake reference to be rewritten.";
               };
-              to = mkOption {
+              to = {
                 type = referenceAttrs;
                 example = { type = "github"; owner = "my-org"; repo = "my-nixpkgs"; };
                 description = lib.mdDoc "The flake reference {option}`from` is rewritten to.";
               };
-              flake = mkOption {
+              flake = {
                 type = types.nullOr types.attrs;
                 default = null;
                 example = literalExpression "nixpkgs";
@@ -427,7 +427,7 @@ lib.simpleOptions {
                   The flake input {option}`from` is rewritten to.
                 '';
               };
-              exact = mkOption {
+              exact = {
                 type = types.bool;
                 default = true;
                 description = lib.mdDoc ''

--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -110,7 +110,7 @@ let
 
 in
 
-lib.simple-module {
+lib.simpleOptions {
   imports = [
     (mkRenamedOptionModuleWith { sinceRelease = 2003; from = [ "nix" "useChroot" ]; to = [ "nix" "useSandbox" ]; })
     (mkRenamedOptionModuleWith { sinceRelease = 2003; from = [ "nix" "chrootDirs" ]; to = [ "nix" "sandboxPaths" ]; })

--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -110,7 +110,7 @@ let
 
 in
 
-{
+lib.simple-module {
   imports = [
     (mkRenamedOptionModuleWith { sinceRelease = 2003; from = [ "nix" "useChroot" ]; to = [ "nix" "useSandbox" ]; })
     (mkRenamedOptionModuleWith { sinceRelease = 2003; from = [ "nix" "chrootDirs" ]; to = [ "nix" "sandboxPaths" ]; })
@@ -122,10 +122,8 @@ in
   ###### interface
 
   options = {
-
-    nix = {
-
-      enable = mkOption {
+    nix.options = {
+      enable = {
         type = types.bool;
         default = true;
         description = lib.mdDoc ''
@@ -134,7 +132,7 @@ in
         '';
       };
 
-      package = mkOption {
+      package = {
         type = types.package;
         default = pkgs.nix;
         defaultText = literalExpression "pkgs.nix";
@@ -143,7 +141,7 @@ in
         '';
       };
 
-      distributedBuilds = mkOption {
+      distributedBuilds = {
         type = types.bool;
         default = false;
         description = lib.mdDoc ''
@@ -152,7 +150,7 @@ in
         '';
       };
 
-      daemonCPUSchedPolicy = mkOption {
+      daemonCPUSchedPolicy = {
         type = types.enum [ "other" "batch" "idle" ];
         default = "other";
         example = "batch";
@@ -182,7 +180,7 @@ in
       '';
       };
 
-      daemonIOSchedClass = mkOption {
+      daemonIOSchedClass = {
         type = types.enum [ "best-effort" "idle" ];
         default = "best-effort";
         example = "idle";
@@ -205,7 +203,7 @@ in
       '';
       };
 
-      daemonIOSchedPriority = mkOption {
+      daemonIOSchedPriority = {
         type = types.int;
         default = 4;
         example = 1;
@@ -218,17 +216,17 @@ in
         '';
       };
 
-      buildMachines = mkOption {
-        type = types.listOf (types.submodule {
+      buildMachines = {
+        listOf = {
           options = {
-            hostName = mkOption {
+            hostName = {
               type = types.str;
               example = "nixbuilder.example.org";
               description = lib.mdDoc ''
                 The hostname of the build machine.
               '';
             };
-            protocol = mkOption {
+            protocol = {
               type = types.enum [ null "ssh" "ssh-ng" ];
               default = "ssh";
               example = "ssh-ng";
@@ -241,7 +239,7 @@ in
                 without a protocol which is for example used by hydra.
               '';
             };
-            system = mkOption {
+            system = {
               type = types.nullOr types.str;
               default = null;
               example = "x86_64-linux";
@@ -252,7 +250,7 @@ in
                 both are set.
               '';
             };
-            systems = mkOption {
+            systems = {
               type = types.listOf types.str;
               default = [ ];
               example = [ "x86_64-linux" "aarch64-linux" ];
@@ -263,7 +261,7 @@ in
                 both are set.
               '';
             };
-            sshUser = mkOption {
+            sshUser = {
               type = types.nullOr types.str;
               default = null;
               example = "builder";
@@ -274,7 +272,7 @@ in
                 {option}`nix.settings.trusted-users`.
               '';
             };
-            sshKey = mkOption {
+            sshKey = {
               type = types.nullOr types.str;
               default = null;
               example = "/root/.ssh/id_buildhost_builduser";
@@ -288,7 +286,7 @@ in
                 in the local filesystem, *not* to the nix store.
               '';
             };
-            maxJobs = mkOption {
+            maxJobs = {
               type = types.int;
               default = 1;
               description = lib.mdDoc ''
@@ -298,7 +296,7 @@ in
                 machines.
               '';
             };
-            speedFactor = mkOption {
+            speedFactor = {
               type = types.int;
               default = 1;
               description = lib.mdDoc ''
@@ -307,7 +305,7 @@ in
                 builders. Higher is faster.
               '';
             };
-            mandatoryFeatures = mkOption {
+            mandatoryFeatures = {
               type = types.listOf types.str;
               default = [ ];
               example = [ "big-parallel" ];
@@ -318,7 +316,7 @@ in
                 {var}`supportedFeatures`.
               '';
             };
-            supportedFeatures = mkOption {
+            supportedFeatures = {
               type = types.listOf types.str;
               default = [ ];
               example = [ "kvm" "big-parallel" ];
@@ -328,7 +326,7 @@ in
                 list.
               '';
             };
-            publicHostKey = mkOption {
+            publicHostKey = {
               type = types.nullOr types.str;
               default = null;
               description = lib.mdDoc ''
@@ -338,7 +336,7 @@ in
               '';
             };
           };
-        });
+        };
         default = [ ];
         description = lib.mdDoc ''
           This option lists the machines to be used if distributed builds are
@@ -350,14 +348,14 @@ in
       };
 
       # Environment variables for running Nix.
-      envVars = mkOption {
+      envVars = {
         type = types.attrs;
         internal = true;
         default = { };
         description = lib.mdDoc "Environment variables used by Nix.";
       };
 
-      nrBuildUsers = mkOption {
+      nrBuildUsers = {
         type = types.int;
         description = lib.mdDoc ''
           Number of `nixbld` user accounts created to
@@ -367,7 +365,7 @@ in
         '';
       };
 
-      nixPath = mkOption {
+      nixPath = {
         type = types.listOf types.str;
         default = [
           "nixpkgs=/nix/var/nix/profiles/per-user/root/channels/nixos"
@@ -381,7 +379,7 @@ in
         '';
       };
 
-      checkConfig = mkOption {
+      checkConfig = {
         type = types.bool;
         default = true;
         description = lib.mdDoc ''
@@ -389,7 +387,7 @@ in
         '';
       };
 
-      checkAllErrors = mkOption {
+      checkAllErrors = {
         type = types.bool;
         default = true;
         description = lib.mdDoc ''
@@ -397,8 +395,8 @@ in
         '';
       };
 
-      registry = mkOption {
-        type = types.attrsOf (types.submodule (
+      registry = {
+        attrsOf = types.submodule (
           let
             referenceAttrs = with types; attrsOf (oneOf [
               str
@@ -451,14 +449,14 @@ in
               ));
             };
           }
-        ));
+        );
         default = { };
         description = lib.mdDoc ''
           A system-wide flake registry.
         '';
       };
 
-      extraOptions = mkOption {
+      extraOptions = {
         type = types.lines;
         default = "";
         example = ''
@@ -468,191 +466,189 @@ in
         description = lib.mdDoc "Additional text appended to {file}`nix.conf`.";
       };
 
-      settings = mkOption {
-        type = types.submodule {
-          freeformType = semanticConfType;
+      settings = {
+        # freeformType = semanticConfType;  #TODO
 
-          options = {
-            max-jobs = mkOption {
-              type = types.either types.int (types.enum [ "auto" ]);
-              default = "auto";
-              example = 64;
-              description = lib.mdDoc ''
-                This option defines the maximum number of jobs that Nix will try to
-                build in parallel. The default is auto, which means it will use all
-                available logical cores. It is recommend to set it to the total
-                number of logical cores in your system (e.g., 16 for two CPUs with 4
-                cores each and hyper-threading).
-              '';
-            };
+        options = {
+          max-jobs = mkOption {
+            type = types.either types.int (types.enum [ "auto" ]);
+            default = "auto";
+            example = 64;
+            description = lib.mdDoc ''
+              This option defines the maximum number of jobs that Nix will try to
+              build in parallel. The default is auto, which means it will use all
+              available logical cores. It is recommend to set it to the total
+              number of logical cores in your system (e.g., 16 for two CPUs with 4
+              cores each and hyper-threading).
+            '';
+          };
 
-            auto-optimise-store = mkOption {
-              type = types.bool;
-              default = false;
-              example = true;
-              description = lib.mdDoc ''
-                If set to true, Nix automatically detects files in the store that have
-                identical contents, and replaces them with hard links to a single copy.
-                This saves disk space. If set to false (the default), you can still run
-                nix-store --optimise to get rid of duplicate files.
-              '';
-            };
+          auto-optimise-store = {
+            type = types.bool;
+            default = false;
+            example = true;
+            description = lib.mdDoc ''
+              If set to true, Nix automatically detects files in the store that have
+              identical contents, and replaces them with hard links to a single copy.
+              This saves disk space. If set to false (the default), you can still run
+              nix-store --optimise to get rid of duplicate files.
+            '';
+          };
 
-            cores = mkOption {
-              type = types.int;
-              default = 0;
-              example = 64;
-              description = lib.mdDoc ''
-                This option defines the maximum number of concurrent tasks during
-                one build. It affects, e.g., -j option for make.
-                The special value 0 means that the builder should use all
-                available CPU cores in the system. Some builds may become
-                non-deterministic with this option; use with care! Packages will
-                only be affected if enableParallelBuilding is set for them.
-              '';
-            };
+          cores = {
+            type = types.int;
+            default = 0;
+            example = 64;
+            description = lib.mdDoc ''
+              This option defines the maximum number of concurrent tasks during
+              one build. It affects, e.g., -j option for make.
+              The special value 0 means that the builder should use all
+              available CPU cores in the system. Some builds may become
+              non-deterministic with this option; use with care! Packages will
+              only be affected if enableParallelBuilding is set for them.
+            '';
+          };
 
-            sandbox = mkOption {
-              type = types.either types.bool (types.enum [ "relaxed" ]);
-              default = true;
-              description = lib.mdDoc ''
-                If set, Nix will perform builds in a sandboxed environment that it
-                will set up automatically for each build. This prevents impurities
-                in builds by disallowing access to dependencies outside of the Nix
-                store by using network and mount namespaces in a chroot environment.
-                This is enabled by default even though it has a possible performance
-                impact due to the initial setup time of a sandbox for each build. It
-                doesn't affect derivation hashes, so changing this option will not
-                trigger a rebuild of packages.
-              '';
-            };
+          sandbox = {
+            type = types.either types.bool (types.enum [ "relaxed" ]);
+            default = true;
+            description = lib.mdDoc ''
+              If set, Nix will perform builds in a sandboxed environment that it
+              will set up automatically for each build. This prevents impurities
+              in builds by disallowing access to dependencies outside of the Nix
+              store by using network and mount namespaces in a chroot environment.
+              This is enabled by default even though it has a possible performance
+              impact due to the initial setup time of a sandbox for each build. It
+              doesn't affect derivation hashes, so changing this option will not
+              trigger a rebuild of packages.
+            '';
+          };
 
-            extra-sandbox-paths = mkOption {
-              type = types.listOf types.str;
-              default = [ ];
-              example = [ "/dev" "/proc" ];
-              description = lib.mdDoc ''
-                Directories from the host filesystem to be included
-                in the sandbox.
-              '';
-            };
+          extra-sandbox-paths = {
+            listOf = types.str;
+            default = [ ];
+            example = [ "/dev" "/proc" ];
+            description = lib.mdDoc ''
+              Directories from the host filesystem to be included
+              in the sandbox.
+            '';
+          };
 
-            substituters = mkOption {
-              type = types.listOf types.str;
-              description = lib.mdDoc ''
-                List of binary cache URLs used to obtain pre-built binaries
-                of Nix packages.
+          substituters = {
+            listOf = types.str;
+            description = lib.mdDoc ''
+              List of binary cache URLs used to obtain pre-built binaries
+              of Nix packages.
 
-                By default https://cache.nixos.org/ is added.
-              '';
-            };
+              By default https://cache.nixos.org/ is added.
+            '';
+          };
 
-            trusted-substituters = mkOption {
-              type = types.listOf types.str;
-              default = [ ];
-              example = [ "https://hydra.nixos.org/" ];
-              description = lib.mdDoc ''
-                List of binary cache URLs that non-root users can use (in
-                addition to those specified using
-                {option}`nix.settings.substituters`) by passing
-                `--option binary-caches` to Nix commands.
-              '';
-            };
+          trusted-substituters = {
+            listOf = types.str;
+            default = [ ];
+            example = [ "https://hydra.nixos.org/" ];
+            description = lib.mdDoc ''
+              List of binary cache URLs that non-root users can use (in
+              addition to those specified using
+              {option}`nix.settings.substituters`) by passing
+              `--option binary-caches` to Nix commands.
+            '';
+          };
 
-            require-sigs = mkOption {
-              type = types.bool;
-              default = true;
-              description = lib.mdDoc ''
-                If enabled (the default), Nix will only download binaries from binary caches if
-                they are cryptographically signed with any of the keys listed in
-                {option}`nix.settings.trusted-public-keys`. If disabled, signatures are neither
-                required nor checked, so it's strongly recommended that you use only
-                trustworthy caches and https to prevent man-in-the-middle attacks.
-              '';
-            };
+          require-sigs = {
+            type = types.bool;
+            default = true;
+            description = lib.mdDoc ''
+              If enabled (the default), Nix will only download binaries from binary caches if
+              they are cryptographically signed with any of the keys listed in
+              {option}`nix.settings.trusted-public-keys`. If disabled, signatures are neither
+              required nor checked, so it's strongly recommended that you use only
+              trustworthy caches and https to prevent man-in-the-middle attacks.
+            '';
+          };
 
-            trusted-public-keys = mkOption {
-              type = types.listOf types.str;
-              example = [ "hydra.nixos.org-1:CNHJZBh9K4tP3EKF6FkkgeVYsS3ohTl+oS0Qa8bezVs=" ];
-              description = lib.mdDoc ''
-                List of public keys used to sign binary caches. If
-                {option}`nix.settings.trusted-public-keys` is enabled,
-                then Nix will use a binary from a binary cache if and only
-                if it is signed by *any* of the keys
-                listed here. By default, only the key for
-                `cache.nixos.org` is included.
-              '';
-            };
+          trusted-public-keys = {
+            listOf = types.str;
+            example = [ "hydra.nixos.org-1:CNHJZBh9K4tP3EKF6FkkgeVYsS3ohTl+oS0Qa8bezVs=" ];
+            description = lib.mdDoc ''
+              List of public keys used to sign binary caches. If
+              {option}`nix.settings.trusted-public-keys` is enabled,
+              then Nix will use a binary from a binary cache if and only
+              if it is signed by *any* of the keys
+              listed here. By default, only the key for
+              `cache.nixos.org` is included.
+            '';
+          };
 
-            trusted-users = mkOption {
-              type = types.listOf types.str;
-              default = [ "root" ];
-              example = [ "root" "alice" "@wheel" ];
-              description = lib.mdDoc ''
-                A list of names of users that have additional rights when
-                connecting to the Nix daemon, such as the ability to specify
-                additional binary caches, or to import unsigned NARs. You
-                can also specify groups by prefixing them with
-                `@`; for instance,
-                `@wheel` means all users in the wheel
-                group.
-              '';
-            };
+          trusted-users = {
+            listOf = types.str;
+            default = [ "root" ];
+            example = [ "root" "alice" "@wheel" ];
+            description = lib.mdDoc ''
+              A list of names of users that have additional rights when
+              connecting to the Nix daemon, such as the ability to specify
+              additional binary caches, or to import unsigned NARs. You
+              can also specify groups by prefixing them with
+              `@`; for instance,
+              `@wheel` means all users in the wheel
+              group.
+            '';
+          };
 
-            system-features = mkOption {
-              type = types.listOf types.str;
-              example = [ "kvm" "big-parallel" "gccarch-skylake" ];
-              description = lib.mdDoc ''
-                The set of features supported by the machine. Derivations
-                can express dependencies on system features through the
-                `requiredSystemFeatures` attribute.
+          system-features = {
+            listOf = types.str;
+            example = [ "kvm" "big-parallel" "gccarch-skylake" ];
+            description = lib.mdDoc ''
+              The set of features supported by the machine. Derivations
+              can express dependencies on system features through the
+              `requiredSystemFeatures` attribute.
 
-                By default, pseudo-features `nixos-test`, `benchmark`,
-                and `big-parallel` used in Nixpkgs are set, `kvm`
-                is also included if it is available.
-              '';
-            };
+              By default, pseudo-features `nixos-test`, `benchmark`,
+              and `big-parallel` used in Nixpkgs are set, `kvm`
+              is also included if it is available.
+            '';
+          };
 
-            allowed-users = mkOption {
-              type = types.listOf types.str;
-              default = [ "*" ];
-              example = [ "@wheel" "@builders" "alice" "bob" ];
-              description = lib.mdDoc ''
-                A list of names of users (separated by whitespace) that are
-                allowed to connect to the Nix daemon. As with
-                {option}`nix.settings.trusted-users`, you can specify groups by
-                prefixing them with `@`. Also, you can
-                allow all users by specifying `*`. The
-                default is `*`. Note that trusted users are
-                always allowed to connect.
-              '';
-            };
+          allowed-users = {
+            listOf = types.str;
+            default = [ "*" ];
+            example = [ "@wheel" "@builders" "alice" "bob" ];
+            description = lib.mdDoc ''
+              A list of names of users (separated by whitespace) that are
+              allowed to connect to the Nix daemon. As with
+              {option}`nix.settings.trusted-users`, you can specify groups by
+              prefixing them with `@`. Also, you can
+              allow all users by specifying `*`. The
+              default is `*`. Note that trusted users are
+              always allowed to connect.
+            '';
           };
         };
-        default = { };
-        example = literalExpression ''
-          {
-            use-sandbox = true;
-            show-trace = true;
-
-            system-features = [ "big-parallel" "kvm" "recursive-nix" ];
-            sandbox-paths = { "/bin/sh" = "''${pkgs.busybox-sandbox-shell.out}/bin/busybox"; };
-          }
-        '';
-        description = lib.mdDoc ''
-          Configuration for Nix, see
-          <https://nixos.org/manual/nix/stable/#sec-conf-file> or
-          {manpage}`nix.conf(5)` for available options.
-          The value declared here will be translated directly to the key-value pairs Nix expects.
-
-          You can use {command}`nix-instantiate --eval --strict '<nixpkgs/nixos>' -A config.nix.settings`
-          to view the current value. By default it is empty.
-
-          Nix configurations defined under {option}`nix.*` will be translated and applied to this
-          option. In addition, configuration specified in {option}`nix.extraOptions` which will be appended
-          verbatim to the resulting config file.
-        '';
       };
+      default = { };
+      example = literalExpression ''
+        {
+          use-sandbox = true;
+          show-trace = true;
+
+          system-features = [ "big-parallel" "kvm" "recursive-nix" ];
+          sandbox-paths = { "/bin/sh" = "''${pkgs.busybox-sandbox-shell.out}/bin/busybox"; };
+        }
+      '';
+      description = lib.mdDoc ''
+        Configuration for Nix, see
+        <https://nixos.org/manual/nix/stable/#sec-conf-file> or
+        {manpage}`nix.conf(5)` for available options.
+        The value declared here will be translated directly to the key-value pairs Nix expects.
+
+        You can use {command}`nix-instantiate --eval --strict '<nixpkgs/nixos>' -A config.nix.settings`
+        to view the current value. By default it is empty.
+
+        Nix configurations defined under {option}`nix.*` will be translated and applied to this
+        option. In addition, configuration specified in {option}`nix.extraOptions` which will be appended
+        verbatim to the resulting config file.
+      '';
     };
   };
 

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -173,243 +173,188 @@ let
 
 in
 
-{
+lib.simpleOptions {
   ###### interface
 
-  options = {
+  options.systemd.options = {
+    package.default      = pkgs.systemd;
+    package.defaultText  = literalExpression "pkgs.systemd";
+    package.type         = types.package;
+    package.description  = lib.mdDoc "The systemd package.";
 
-    systemd.package = mkOption {
-      default = pkgs.systemd;
-      defaultText = literalExpression "pkgs.systemd";
-      type = types.package;
-      description = lib.mdDoc "The systemd package.";
-    };
+    units.description    = lib.mdDoc "Definition of systemd units.";
+    units.default        = {};
+    units.type           = systemdUtils.types.units;
 
-    systemd.units = mkOption {
-      description = lib.mdDoc "Definition of systemd units.";
-      default = {};
-      type = systemdUtils.types.units;
-    };
+    packages.default     = [];
+    packages.listOf      = types.package;
+    packages.example     = literalExpression "[ pkgs.systemd-cryptsetup-generator ]";
+    packages.description = lib.mdDoc "Packages providing systemd units and hooks.";
 
-    systemd.packages = mkOption {
-      default = [];
-      type = types.listOf types.package;
-      example = literalExpression "[ pkgs.systemd-cryptsetup-generator ]";
-      description = lib.mdDoc "Packages providing systemd units and hooks.";
-    };
+    targets.default      = {};
+    targets.type         = systemdUtils.types.targets;
+    targets.description  = lib.mdDoc "Definition of systemd target units.";
 
-    systemd.targets = mkOption {
-      default = {};
-      type = systemdUtils.types.targets;
-      description = lib.mdDoc "Definition of systemd target units.";
-    };
+    services.default     = {};
+    services.type        = systemdUtils.types.services;
+    services.description = lib.mdDoc "Definition of systemd service units.";
 
-    systemd.services = mkOption {
-      default = {};
-      type = systemdUtils.types.services;
-      description = lib.mdDoc "Definition of systemd service units.";
-    };
+    sockets.default      = {};
+    sockets.type         = systemdUtils.types.sockets;
+    sockets.description  = lib.mdDoc "Definition of systemd socket units.";
 
-    systemd.sockets = mkOption {
-      default = {};
-      type = systemdUtils.types.sockets;
-      description = lib.mdDoc "Definition of systemd socket units.";
-    };
+    timers.default       = {};
+    timers.type          = systemdUtils.types.timers;
+    timers.description   = lib.mdDoc "Definition of systemd timer units.";
 
-    systemd.timers = mkOption {
-      default = {};
-      type = systemdUtils.types.timers;
-      description = lib.mdDoc "Definition of systemd timer units.";
-    };
+    paths.default        = {};
+    paths.type           = systemdUtils.types.paths;
+    paths.description    = lib.mdDoc "Definition of systemd path units.";
 
-    systemd.paths = mkOption {
-      default = {};
-      type = systemdUtils.types.paths;
-      description = lib.mdDoc "Definition of systemd path units.";
-    };
+    mounts.default       = [];
+    mounts.type          = systemdUtils.types.mounts;
+    mounts.description   = lib.mdDoc ''
+      Definition of systemd mount units.
+      This is a list instead of an attrSet, because systemd mandates the names to be derived from
+      the 'where' attribute.
+    '';
 
-    systemd.mounts = mkOption {
-      default = [];
-      type = systemdUtils.types.mounts;
-      description = lib.mdDoc ''
-        Definition of systemd mount units.
-        This is a list instead of an attrSet, because systemd mandates the names to be derived from
-        the 'where' attribute.
-      '';
-    };
+    automounts.default     = [];
+    automounts.type        = systemdUtils.types.automounts;
+    automounts.description = lib.mdDoc ''
+      Definition of systemd automount units.
+      This is a list instead of an attrSet, because systemd mandates the names to be derived from
+      the 'where' attribute.
+    '';
 
-    systemd.automounts = mkOption {
-      default = [];
-      type = systemdUtils.types.automounts;
-      description = lib.mdDoc ''
-        Definition of systemd automount units.
-        This is a list instead of an attrSet, because systemd mandates the names to be derived from
-        the 'where' attribute.
-      '';
-    };
+    slices.default     = {};
+    slices.type        = systemdUtils.types.slices;
+    slices.description = lib.mdDoc "Definition of slice configurations.";
 
-    systemd.slices = mkOption {
-      default = {};
-      type = systemdUtils.types.slices;
-      description = lib.mdDoc "Definition of slice configurations.";
-    };
+    generators.type        = types.attrsOf types.path;
+    generators.default     = {};
+    generators.example     = { systemd-gpt-auto-generator = "/dev/null"; };
+    generators.description = lib.mdDoc ''
+      Definition of systemd generators.
+      For each `NAME = VALUE` pair of the attrSet, a link is generated from
+      `/etc/systemd/system-generators/NAME` to `VALUE`.
+    '';
 
-    systemd.generators = mkOption {
-      type = types.attrsOf types.path;
-      default = {};
-      example = { systemd-gpt-auto-generator = "/dev/null"; };
-      description = lib.mdDoc ''
-        Definition of systemd generators.
-        For each `NAME = VALUE` pair of the attrSet, a link is generated from
-        `/etc/systemd/system-generators/NAME` to `VALUE`.
-      '';
-    };
+    shutdown.attrsOf     = types.path;
+    shutdown.default     = {};
+    shutdown.description = lib.mdDoc ''
+      Definition of systemd shutdown executables.
+      For each `NAME = VALUE` pair of the attrSet, a link is generated from
+      `/etc/systemd/system-shutdown/NAME` to `VALUE`.
+    '';
 
-    systemd.shutdown = mkOption {
-      type = types.attrsOf types.path;
-      default = {};
-      description = lib.mdDoc ''
-        Definition of systemd shutdown executables.
-        For each `NAME = VALUE` pair of the attrSet, a link is generated from
-        `/etc/systemd/system-shutdown/NAME` to `VALUE`.
-      '';
-    };
+    defaultUnit.default     = "multi-user.target";
+    defaultUnit.type        = types.str;
+    defaultUnit.description = lib.mdDoc "Default unit started when the system boots.";
 
-    systemd.defaultUnit = mkOption {
-      default = "multi-user.target";
-      type = types.str;
-      description = lib.mdDoc "Default unit started when the system boots.";
-    };
+    ctrlAltDelUnit.default     = "reboot.target";
+    ctrlAltDelUnit.type        = types.str;
+    ctrlAltDelUnit.example     = "poweroff.target";
+    ctrlAltDelUnit.description = lib.mdDoc ''
+      Target that should be started when Ctrl-Alt-Delete is pressed.
+    '';
 
-    systemd.ctrlAltDelUnit = mkOption {
-      default = "reboot.target";
-      type = types.str;
-      example = "poweroff.target";
-      description = lib.mdDoc ''
-        Target that should be started when Ctrl-Alt-Delete is pressed.
-      '';
-    };
+    globalEnvironment.attrsOf     = with types; nullOr (oneOf [ str path package ]);
+    globalEnvironment.default     = {};
+    globalEnvironment.example     = { TZ = "CET"; };
+    globalEnvironment.description = lib.mdDoc ''
+      Environment variables passed to *all* systemd units.
+    '';
 
-    systemd.globalEnvironment = mkOption {
-      type = with types; attrsOf (nullOr (oneOf [ str path package ]));
-      default = {};
-      example = { TZ = "CET"; };
-      description = lib.mdDoc ''
-        Environment variables passed to *all* systemd units.
-      '';
-    };
+    managerEnvironment.attrsOf    = with types; nullOr (oneOf [ str path package ]);
+    managerEnvironment.default    = {};
+    managerEnvironment.example    = { SYSTEMD_LOG_LEVEL = "debug"; };
+    managerEnvironment.description = lib.mdDoc ''
+      Environment variables of PID 1. These variables are
+      *not* passed to started units.
+    '';
 
-    systemd.managerEnvironment = mkOption {
-      type = with types; attrsOf (nullOr (oneOf [ str path package ]));
-      default = {};
-      example = { SYSTEMD_LOG_LEVEL = "debug"; };
-      description = lib.mdDoc ''
-        Environment variables of PID 1. These variables are
-        *not* passed to started units.
-      '';
-    };
+    enableCgroupAccounting.default     = true;
+    enableCgroupAccounting.type        = types.bool;
+    enableCgroupAccounting.description = lib.mdDoc ''
+      Whether to enable cgroup accounting.
+    '';
 
-    systemd.enableCgroupAccounting = mkOption {
-      default = true;
-      type = types.bool;
-      description = lib.mdDoc ''
-        Whether to enable cgroup accounting.
-      '';
-    };
+    enableUnifiedCgroupHierarchy.default     = true;
+    enableUnifiedCgroupHierarchy.type        = types.bool;
+    enableUnifiedCgroupHierarchy.description = lib.mdDoc ''
+      Whether to enable the unified cgroup hierarchy (cgroupsv2).
+    '';
 
-    systemd.enableUnifiedCgroupHierarchy = mkOption {
-      default = true;
-      type = types.bool;
-      description = lib.mdDoc ''
-        Whether to enable the unified cgroup hierarchy (cgroupsv2).
-      '';
-    };
+    extraConfig.default     = "";
+    extraConfig.type        = types.lines;
+    extraConfig.example     = "DefaultLimitCORE=infinity";
+    extraConfig.description = lib.mdDoc ''
+      Extra config options for systemd. See systemd-system.conf(5) man page
+      for available options.
+    '';
 
-    systemd.extraConfig = mkOption {
-      default = "";
-      type = types.lines;
-      example = "DefaultLimitCORE=infinity";
-      description = lib.mdDoc ''
-        Extra config options for systemd. See systemd-system.conf(5) man page
-        for available options.
-      '';
-    };
+    sleep.options.extraConfig.default     = "";
+    sleep.options.extraConfig.type        = types.lines;
+    sleep.options.extraConfig.example     = "HibernateDelaySec=1h";
+    sleep.options.extraConfig.description = lib.mdDoc ''
+      Extra config options for systemd sleep state logic.
+      See sleep.conf.d(5) man page for available options.
+    '';
 
-    systemd.sleep.extraConfig = mkOption {
-      default = "";
-      type = types.lines;
-      example = "HibernateDelaySec=1h";
-      description = lib.mdDoc ''
-        Extra config options for systemd sleep state logic.
-        See sleep.conf.d(5) man page for available options.
-      '';
-    };
+    additionalUpstreamSystemUnits.default     = [ ];
+    additionalUpstreamSystemUnits.listOf      = types.str;
+    additionalUpstreamSystemUnits.example     = [ "debug-shell.service" "systemd-quotacheck.service" ];
+    additionalUpstreamSystemUnits.description = lib.mdDoc ''
+      Additional units shipped with systemd that shall be enabled.
+    '';
 
-    systemd.additionalUpstreamSystemUnits = mkOption {
-      default = [ ];
-      type = types.listOf types.str;
-      example = [ "debug-shell.service" "systemd-quotacheck.service" ];
-      description = lib.mdDoc ''
-        Additional units shipped with systemd that shall be enabled.
-      '';
-    };
+    suppressedSystemUnits.default     = [ ];
+    suppressedSystemUnits.listOf      = types.str;
+    suppressedSystemUnits.example     = [ "systemd-backlight@.service" ];
+    suppressedSystemUnits.description = lib.mdDoc ''
+      A list of units to skip when generating system systemd configuration directory. This has
+      priority over upstream units, {option}`systemd.units`, and
+      {option}`systemd.additionalUpstreamSystemUnits`. The main purpose of this is to
+      prevent a upstream systemd unit from being added to the initrd with any modifications made to it
+      by other NixOS modules.
+    '';
 
-    systemd.suppressedSystemUnits = mkOption {
-      default = [ ];
-      type = types.listOf types.str;
-      example = [ "systemd-backlight@.service" ];
-      description = lib.mdDoc ''
-        A list of units to skip when generating system systemd configuration directory. This has
-        priority over upstream units, {option}`systemd.units`, and
-        {option}`systemd.additionalUpstreamSystemUnits`. The main purpose of this is to
-        prevent a upstream systemd unit from being added to the initrd with any modifications made to it
-        by other NixOS modules.
-      '';
-    };
+    watchdog.options.device.type        = types.nullOr types.path;
+    watchdog.options.device.default     = null;
+    watchdog.options.device.example     = "/dev/watchdog";
+    watchdog.options.device.description = lib.mdDoc ''
+      The path to a hardware watchdog device which will be managed by systemd.
+      If not specified, systemd will default to /dev/watchdog.
+    '';
 
-    systemd.watchdog.device = mkOption {
-      type = types.nullOr types.path;
-      default = null;
-      example = "/dev/watchdog";
-      description = lib.mdDoc ''
-        The path to a hardware watchdog device which will be managed by systemd.
-        If not specified, systemd will default to /dev/watchdog.
-      '';
-    };
+    watchdog.options.runtimeTime.type        = types.nullOr types.str;
+    watchdog.options.runtimeTime.default     = null;
+    watchdog.options.runtimeTime.example     = "30s";
+    watchdog.options.runtimeTime.description = lib.mdDoc ''
+      The amount of time which can elapse before a watchdog hardware device
+      will automatically reboot the system. Valid time units include "ms",
+      "s", "min", "h", "d", and "w".
+    '';
 
-    systemd.watchdog.runtimeTime = mkOption {
-      type = types.nullOr types.str;
-      default = null;
-      example = "30s";
-      description = lib.mdDoc ''
-        The amount of time which can elapse before a watchdog hardware device
-        will automatically reboot the system. Valid time units include "ms",
-        "s", "min", "h", "d", and "w".
-      '';
-    };
+    watchdog.options.rebootTime.type        = types.nullOr types.str;
+    watchdog.options.rebootTime.default     = null;
+    watchdog.options.rebootTime.example     = "10m";
+    watchdog.options.rebootTime.description = lib.mdDoc ''
+      The amount of time which can elapse after a reboot has been triggered
+      before a watchdog hardware device will automatically reboot the system.
+      Valid time units include "ms", "s", "min", "h", "d", and "w".
+    '';
 
-    systemd.watchdog.rebootTime = mkOption {
-      type = types.nullOr types.str;
-      default = null;
-      example = "10m";
-      description = lib.mdDoc ''
-        The amount of time which can elapse after a reboot has been triggered
-        before a watchdog hardware device will automatically reboot the system.
-        Valid time units include "ms", "s", "min", "h", "d", and "w".
-      '';
-    };
-
-    systemd.watchdog.kexecTime = mkOption {
-      type = types.nullOr types.str;
-      default = null;
-      example = "10m";
-      description = lib.mdDoc ''
-        The amount of time which can elapse when kexec is being executed before
-        a watchdog hardware device will automatically reboot the system. This
-        option should only be enabled if reloadTime is also enabled. Valid
-        time units include "ms", "s", "min", "h", "d", and "w".
-      '';
-    };
+    watchdog.options.kexecTime.type        = types.nullOr types.str;
+    watchdog.options.kexecTime.default     = null;
+    watchdog.options.kexecTime.example     = "10m";
+    watchdog.options.kexecTime.description = lib.mdDoc ''
+      The amount of time which can elapse when kexec is being executed before
+      a watchdog hardware device will automatically reboot the system. This
+      option should only be enabled if reloadTime is also enabled. Valid
+      time units include "ms", "s", "min", "h", "d", and "w".
+    '';
   };
 
 


### PR DESCRIPTION
This isn't intended to be merged, only to check what could do with some actual modules, and maybe test with lib.simpleOptions.

> Not eager to merge  NixOS/nixpkgs/pull/#234990 yet, as we'll have to teach everyone and our documentation is already strained, but I think it's worth playing around with.

by @roberth


For nix-daemon.nix we chaged only mkOption and type functions
For systemd.nix we changed function calls and style (that wasn't possible before)