### PR TITLE
lib.simpleOptions: playing hard around with

### DIFF
--- a/lib/simple-options.nix
+++ b/lib/simple-options.nix
@@ -1,12 +1,12 @@
 {
   lib,
-  attrAttr  ? "attrsOf",
-  listAttr  ? "listOf",
-  nullAttr  ? "nullOr",
-  subMAttr  ? "options",
-  typeAttr  ? "type",
-  docAttr   ? "mdDoc",
-  debug     ? false,
+  attrAttr ? "attrsOf",
+  debug    ? false,
+  descAttr ? "mdDoc",
+  listAttr ? "listOf",
+  nullAttr ? "nullOr",
+  subMAttr ? "options",
+  typeAttr ? "type",
   ...
 }:
 module:
@@ -90,21 +90,21 @@ let
       if typeOf optDef     != "set"
         then throw ''optDef must be a attrset, instead it is a ${typeOf optDef}, breadcrumb: ${concatStringsSep "." breadcrumb}, optName: ${optName}'' else
       if optDef ? ${typeAttr}
-        then removeAttrs optDef [docAttr typeAttr] // { type = optDef.${typeAttr}; } else
+        then removeAttrs optDef [descAttr typeAttr] // { type = optDef.${typeAttr}; } else
       if optDef ? ${attrAttr}
-        then removeAttrs optDef [docAttr attrAttr] // { type = lazyAttrsOf (toType    (breadcrumb ++ [optName attrAttr]) optDef.${attrAttr}); } else
+        then removeAttrs optDef [descAttr attrAttr] // { type = lazyAttrsOf (toType    (breadcrumb ++ [optName attrAttr]) optDef.${attrAttr}); } else
       if optDef ? ${listAttr}
-        then removeAttrs optDef [docAttr listAttr] // { type = listOf      (toType    (breadcrumb ++ [optName listAttr]) optDef.${listAttr}); } else
+        then removeAttrs optDef [descAttr listAttr] // { type = listOf      (toType    (breadcrumb ++ [optName listAttr]) optDef.${listAttr}); } else
       if optDef ? ${nullAttr}
-        then removeAttrs optDef [docAttr nullAttr] // { type = nullOr      (toType    (breadcrumb ++ [optName nullAttr]) optDef.${nullAttr}); } else
+        then removeAttrs optDef [descAttr nullAttr] // { type = nullOr      (toType    (breadcrumb ++ [optName nullAttr]) optDef.${nullAttr}); } else
       if optDef ? ${subMAttr}
-        then removeAttrs optDef [docAttr subMAttr] // { type = submodule   (toOptions (breadcrumb ++ [optName subMAttr]) optDef.${subMAttr}); } else
+        then removeAttrs optDef [descAttr subMAttr] // { type = submodule   (toOptions (breadcrumb ++ [optName subMAttr]) optDef.${subMAttr}); } else
       if optDef ? default
-        then removeAttrs optDef [docAttr]          // { type = toType                 (breadcrumb ++ [optName]         ) optDef             ; } else
+        then removeAttrs optDef [descAttr]          // { type = toType                 (breadcrumb ++ [optName]         ) optDef             ; } else
         throw ''${concatStringsSep "." (breadcrumb ++ optName)} has no attr _type|${typeAttr}|${attrAttr}|${listAttr}|${nullAttr}|${subMAttr}'';
         result' = result // (
-          if  optDef ? ${docAttr}
-          then { description = lib.mdDoc optDef.${docAttr}; }
+          if  optDef ? ${descAttr}
+          then { description = lib.mdDoc optDef.${descAttr}; }
           else  {});
     in
       if debug then

--- a/lib/simple-options.nix
+++ b/lib/simple-options.nix
@@ -6,6 +6,7 @@
   enumAttr ? "enum",
   listAttr ? "listOf",
   nullAttr ? "nullOr",
+  oneOAttr ? "oneOf",
   subMAttr ? "options",
   typeAttr ? "type",
   ...
@@ -13,7 +14,7 @@
 module:
 let
   inherit (builtins) attrNames concatStringsSep mapAttrs throw trace typeOf;
-  inherit (lib.types) lazyAttrsOf listOf submodule anything attrs bool enum float int nullOr package path str;
+  inherit (lib.types) lazyAttrsOf listOf submodule anything attrs bool enum float int nullOr oneOf package path str;
   mkOptionW = breadcrumb: optName: optDef:
     let result = lib.mkOption (toOption breadcrumb optName optDef);
     in
@@ -44,6 +45,8 @@ let
         then type.type else
       if type ? ${enumAttr}
         then enum type.${enumAttr} else
+      if type ? ${oneOAttr}
+        then oneOf type.${oneOAttr} else
       if type ? ${attrAttr}
         then lazyAttrsOf (toType    (breadcrumb ++ [attrAttr]) type."${attrAttr}") else
       if type ? ${listAttr}
@@ -96,6 +99,8 @@ let
         then removeAttrs optDef [descAttr typeAttr] // { type = optDef.${typeAttr}; } else
       if optDef ? ${enumAttr}
         then removeAttrs optDef [descAttr enumAttr] // { type = enum optDef.${enumAttr}; } else
+      if optDef ? ${oneOAttr}
+        then removeAttrs optDef [descAttr oneOAttr] // { type = oneOf optDef.${oneOAttr}; } else
       if optDef ? ${attrAttr}
         then removeAttrs optDef [descAttr attrAttr] // { type = lazyAttrsOf (toType    (breadcrumb ++ [optName attrAttr]) optDef.${attrAttr}); } else
       if optDef ? ${listAttr}

--- a/lib/simple-options.nix
+++ b/lib/simple-options.nix
@@ -87,6 +87,7 @@ let
         result
       else result;
 
+  toTypes   = breadcrumb: types: lib.lists.imap0 (i: v: toType (breadcrumb ++ [(toString i)]) v) types;
   toOption  = breadcrumb: optName: optDef:
     let result =
       if typeOf breadcrumb != "list"
@@ -100,7 +101,7 @@ let
       if optDef ? ${enumAttr}
         then removeAttrs optDef [descAttr enumAttr] // { type = enum optDef.${enumAttr}; } else
       if optDef ? ${oneOAttr}
-        then removeAttrs optDef [descAttr oneOAttr] // { type = oneOf optDef.${oneOAttr}; } else
+        then removeAttrs optDef [descAttr oneOAttr] // { type = oneOf       (toTypes   (breadcrumb ++ [optName oneOAttr]) optDef.${oneOAttr}); } else
       if optDef ? ${attrAttr}
         then removeAttrs optDef [descAttr attrAttr] // { type = lazyAttrsOf (toType    (breadcrumb ++ [optName attrAttr]) optDef.${attrAttr}); } else
       if optDef ? ${listAttr}

--- a/lib/simple-options.nix
+++ b/lib/simple-options.nix
@@ -71,6 +71,8 @@ let
         then listOf anything else
       if type ? default && typeOf type.default == "null"
         then nullOr anything else
+      if type ? default && typeOf type.default == "path"
+        then path else
       if type ? default && typeOf type.default == "string"
         then str else
       throw ''${concatStringsSep "." breadcrumb} has no attr _type|${typeAttr}|${attrAttr}|${listAttr}|${nullAttr}|${subMAttr}'';
@@ -116,7 +118,7 @@ let
         result' = result // (
           if  optDef ? ${descAttr}
           then { description = lib.mdDoc optDef.${descAttr}; }
-          else  {});
+          else {});
     in
       if debug then
         trace ''

--- a/lib/simple-options.nix
+++ b/lib/simple-options.nix
@@ -3,6 +3,7 @@
   attrAttr ? "attrsOf",
   debug    ? false,
   descAttr ? "mdDoc",
+  enumAttr ? "enum",
   listAttr ? "listOf",
   nullAttr ? "nullOr",
   subMAttr ? "options",
@@ -12,7 +13,7 @@
 module:
 let
   inherit (builtins) attrNames concatStringsSep mapAttrs throw trace typeOf;
-  inherit (lib.types) lazyAttrsOf listOf submodule anything attrs bool float int nullOr package path str;
+  inherit (lib.types) lazyAttrsOf listOf submodule anything attrs bool enum float int nullOr package path str;
   mkOptionW = breadcrumb: optName: optDef:
     let result = lib.mkOption (toOption breadcrumb optName optDef);
     in
@@ -41,6 +42,8 @@ let
         then type else
       if type ? ${typeAttr}
         then type.type else
+      if type ? ${enumAttr}
+        then enum type.${enumAttr} else
       if type ? ${attrAttr}
         then lazyAttrsOf (toType    (breadcrumb ++ [attrAttr]) type."${attrAttr}") else
       if type ? ${listAttr}
@@ -91,6 +94,8 @@ let
         then throw ''optDef must be a attrset, instead it is a ${typeOf optDef}, breadcrumb: ${concatStringsSep "." breadcrumb}, optName: ${optName}'' else
       if optDef ? ${typeAttr}
         then removeAttrs optDef [descAttr typeAttr] // { type = optDef.${typeAttr}; } else
+      if optDef ? ${enumAttr}
+        then removeAttrs optDef [descAttr enumAttr] // { type = enum optDef.${enumAttr}; } else
       if optDef ? ${attrAttr}
         then removeAttrs optDef [descAttr attrAttr] // { type = lazyAttrsOf (toType    (breadcrumb ++ [optName attrAttr]) optDef.${attrAttr}); } else
       if optDef ? ${listAttr}

--- a/lib/simple-options.nix
+++ b/lib/simple-options.nix
@@ -46,15 +46,15 @@ let
       if type ? ${enumAttr}
         then enum type.${enumAttr} else
       if type ? ${oneOAttr}
-        then oneOf type.${oneOAttr} else
+        then oneOf       (toTypes   (breadcrumb ++ [oneOAttr]) type.${oneOAttr}) else
       if type ? ${attrAttr}
-        then lazyAttrsOf (toType    (breadcrumb ++ [attrAttr]) type."${attrAttr}") else
+        then lazyAttrsOf (toType    (breadcrumb ++ [attrAttr]) type.${attrAttr}) else
       if type ? ${listAttr}
-        then listOf      (toType    (breadcrumb ++ [listAttr]) type."${listAttr}") else
+        then listOf      (toType    (breadcrumb ++ [listAttr]) type.${listAttr}) else
       if type ? ${nullAttr}
-        then nullOr      (toType    (breadcrumb ++ [nullAttr]) type."${nullAttr}") else
+        then nullOr      (toType    (breadcrumb ++ [nullAttr]) type.${nullAttr}) else
       if type ? ${subMAttr}
-        then submodule   (toOptions (breadcrumb ++ [subMAttr]) type."${subMAttr}") else
+        then submodule   (toOptions (breadcrumb ++ [subMAttr]) type.${subMAttr}) else
       if type ? default && (lib.isDerivation type.default)
         then package else
       if type ? default && typeOf type.default == "set" && type.default ? _type

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -412,6 +412,15 @@ checkConfigOutput '^"OPT-OPT-LST"$' config.OPT.OPT-OPT.OPT-OPT-LST.0    ./simple
 checkConfigOutput '^"OPT-OPT-TYP"$' config.OPT.OPT-OPT.OPT-OPT-TYP      ./simple-options.nix
 checkConfigOutput '^"OPT-TYP"$'     config.OPT.OPT-TYP                  ./simple-options.nix
 checkConfigOutput '^"TYP"$'         config.TYP                          ./simple-options.nix
+checkConfigOutput '^true$'          config.TYP-BOO                      ./simple-options.nix
+checkConfigOutput '^0$'             config.TYP-FLT                      ./simple-options.nix
+checkConfigOutput '^0$'             config.TYP-INT                      ./simple-options.nix
+checkConfigOutput '^"TYP-LST"$'     config.TYP-LST.0                    ./simple-options.nix
+checkConfigOutput '^null$'          config.TYP-NUL                      ./simple-options.nix
+checkConfigOutput '^{ }$'           config.TYP-ATT                      ./simple-options.nix
+checkConfigOutput '^"empty-file"$'  config.TYP-PKG.name                 ./simple-options.nix
+checkConfigOutput '^"TYP-STR"$'     config.TYP-STR                      ./simple-options.nix
+
 
 cat <<EOF
 ====== module tests ======

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -420,6 +420,7 @@ checkConfigOutput '^null$'          config.TYP-NUL                      ./simple
 checkConfigOutput '^{ }$'           config.TYP-ATT                      ./simple-options.nix
 checkConfigOutput '^"empty-file"$'  config.TYP-PKG.name                 ./simple-options.nix
 checkConfigOutput '^"TYP-STR"$'     config.TYP-STR                      ./simple-options.nix
+checkConfigOutput '^"MD doc"$'      options.TYP-DOC.description.text    ./simple-options.nix
 
 
 cat <<EOF

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -401,19 +401,24 @@ checkConfigOutput '^"ATT"$'         config.ATT.test                     ./simple
 checkConfigOutput '^"ATT-ATT"$'     config.ATT-ATT.foo.test             ./simple-options.nix '{ ATT-ATT.foo.test =          "ATT-ATT"; }'
 checkConfigOutput '^"ATT-ENM"$'     config.ATT-ENM.test                 ./simple-options.nix '{ ATT-ENM.test =              "ATT-ENM"; }'
 checkConfigOutput '^"ATT-LST"$'     config.ATT-LST.test.0               ./simple-options.nix '{ ATT-LST.test = [            "ATT-LST" ]; }'
+checkConfigOutput '^"ATT-ONE"$'     config.ATT-ONE.test                 ./simple-options.nix '{ ATT-ONE.test =              "ATT-ONE"; }'
 checkConfigOutput '^"ATT-OPT-TYP"$' config.ATT-OPT.test.ATT-OPT-TYP     ./simple-options.nix '{ ATT-OPT.test.ATT-OPT-TYP =  "ATT-OPT-TYP"; }'
 checkConfigOutput '^"ENM"$'         config.ENM                          ./simple-options.nix
 checkConfigOutput '^"LST"$'         config.LST.0                        ./simple-options.nix
 checkConfigOutput '^"LST-ATT"$'     config.LST-ATT.0.test               ./simple-options.nix '{ LST-ATT = [ { test =        "LST-ATT";} ]; }'
 checkConfigOutput '^"LST-ENM"$'     config.LST-ENM.0                    ./simple-options.nix '{ LST-ENM = [                 "LST-ENM" ]; }'
 checkConfigOutput '^"LST-LST"$'     config.LST-LST.0.0                  ./simple-options.nix '{ LST-LST = [ [               "LST-LST" ] ]; }'
+checkConfigOutput '^"LST-ONE"$'     config.LST-ONE.0                    ./simple-options.nix '{ LST-ONE = [                 "LST-ONE" ]; }'
 checkConfigOutput '^"LST-OPT-TYP"$' config.LST-OPT.0.LST-OPT-TYP        ./simple-options.nix '{ LST-OPT = [ { LST-OPT-TYP = "LST-OPT-TYP"; } ]; }'
+checkConfigOutput '^"ONE"$'         config.ONE                          ./simple-options.nix
 checkConfigOutput '^"OPT-ATT"$'     config.OPT.OPT-ATT.test             ./simple-options.nix
 checkConfigOutput '^"OPT-ENM"$'     config.OPT.OPT-ENM                  ./simple-options.nix
 checkConfigOutput '^"OPT-LST"$'     config.OPT.OPT-LST.0                ./simple-options.nix
+checkConfigOutput '^"OPT-ONE"$'     config.OPT.OPT-ONE                  ./simple-options.nix
 checkConfigOutput '^"OPT-OPT-ATT"$' config.OPT.OPT-OPT.OPT-OPT-ATT.test ./simple-options.nix
 checkConfigOutput '^"OPT-OPT-ENM"$' config.OPT.OPT-OPT.OPT-OPT-ENM      ./simple-options.nix
 checkConfigOutput '^"OPT-OPT-LST"$' config.OPT.OPT-OPT.OPT-OPT-LST.0    ./simple-options.nix
+checkConfigOutput '^"OPT-OPT-ONE"$' config.OPT.OPT-OPT.OPT-OPT-ONE      ./simple-options.nix
 checkConfigOutput '^"OPT-OPT-TYP"$' config.OPT.OPT-OPT.OPT-OPT-TYP      ./simple-options.nix
 checkConfigOutput '^"OPT-TYP"$'     config.OPT.OPT-TYP                  ./simple-options.nix
 checkConfigOutput '^"TYP"$'         config.TYP                          ./simple-options.nix

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -399,15 +399,20 @@ checkConfigOutput '^"pear\\npear"$' config.twice.raw ./merge-module-with-key.nix
 # simpleOptions helper
 checkConfigOutput '^"ATT"$'         config.ATT.test                     ./simple-options.nix
 checkConfigOutput '^"ATT-ATT"$'     config.ATT-ATT.foo.test             ./simple-options.nix '{ ATT-ATT.foo.test =          "ATT-ATT"; }'
+checkConfigOutput '^"ATT-ENM"$'     config.ATT-ENM.test                 ./simple-options.nix '{ ATT-ENM.test =              "ATT-ENM"; }'
 checkConfigOutput '^"ATT-LST"$'     config.ATT-LST.test.0               ./simple-options.nix '{ ATT-LST.test = [            "ATT-LST" ]; }'
 checkConfigOutput '^"ATT-OPT-TYP"$' config.ATT-OPT.test.ATT-OPT-TYP     ./simple-options.nix '{ ATT-OPT.test.ATT-OPT-TYP =  "ATT-OPT-TYP"; }'
+checkConfigOutput '^"ENM"$'         config.ENM                          ./simple-options.nix
 checkConfigOutput '^"LST"$'         config.LST.0                        ./simple-options.nix
 checkConfigOutput '^"LST-ATT"$'     config.LST-ATT.0.test               ./simple-options.nix '{ LST-ATT = [ { test =        "LST-ATT";} ]; }'
+checkConfigOutput '^"LST-ENM"$'     config.LST-ENM.0                    ./simple-options.nix '{ LST-ENM = [                 "LST-ENM" ]; }'
 checkConfigOutput '^"LST-LST"$'     config.LST-LST.0.0                  ./simple-options.nix '{ LST-LST = [ [               "LST-LST" ] ]; }'
 checkConfigOutput '^"LST-OPT-TYP"$' config.LST-OPT.0.LST-OPT-TYP        ./simple-options.nix '{ LST-OPT = [ { LST-OPT-TYP = "LST-OPT-TYP"; } ]; }'
 checkConfigOutput '^"OPT-ATT"$'     config.OPT.OPT-ATT.test             ./simple-options.nix
+checkConfigOutput '^"OPT-ENM"$'     config.OPT.OPT-ENM                  ./simple-options.nix
 checkConfigOutput '^"OPT-LST"$'     config.OPT.OPT-LST.0                ./simple-options.nix
 checkConfigOutput '^"OPT-OPT-ATT"$' config.OPT.OPT-OPT.OPT-OPT-ATT.test ./simple-options.nix
+checkConfigOutput '^"OPT-OPT-ENM"$' config.OPT.OPT-OPT.OPT-OPT-ENM      ./simple-options.nix
 checkConfigOutput '^"OPT-OPT-LST"$' config.OPT.OPT-OPT.OPT-OPT-LST.0    ./simple-options.nix
 checkConfigOutput '^"OPT-OPT-TYP"$' config.OPT.OPT-OPT.OPT-OPT-TYP      ./simple-options.nix
 checkConfigOutput '^"OPT-TYP"$'     config.OPT.OPT-TYP                  ./simple-options.nix

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -422,13 +422,14 @@ checkConfigOutput '^"OPT-OPT-ONE"$' config.OPT.OPT-OPT.OPT-OPT-ONE      ./simple
 checkConfigOutput '^"OPT-OPT-TYP"$' config.OPT.OPT-OPT.OPT-OPT-TYP      ./simple-options.nix
 checkConfigOutput '^"OPT-TYP"$'     config.OPT.OPT-TYP                  ./simple-options.nix
 checkConfigOutput '^"TYP"$'         config.TYP                          ./simple-options.nix
+checkConfigOutput '^{ }$'           config.TYP-ATT                      ./simple-options.nix
 checkConfigOutput '^true$'          config.TYP-BOO                      ./simple-options.nix
 checkConfigOutput '^0$'             config.TYP-FLT                      ./simple-options.nix
 checkConfigOutput '^0$'             config.TYP-INT                      ./simple-options.nix
 checkConfigOutput '^"TYP-LST"$'     config.TYP-LST.0                    ./simple-options.nix
 checkConfigOutput '^null$'          config.TYP-NUL                      ./simple-options.nix
-checkConfigOutput '^{ }$'           config.TYP-ATT                      ./simple-options.nix
 checkConfigOutput '^"empty-file"$'  config.TYP-PKG.name                 ./simple-options.nix
+checkConfigOutput 'tests/modules$'  config.TYP-PTH                      ./simple-options.nix
 checkConfigOutput '^"TYP-STR"$'     config.TYP-STR                      ./simple-options.nix
 checkConfigOutput '^"MD doc"$'      options.TYP-DOC.description.text    ./simple-options.nix
 

--- a/lib/tests/modules/simple-options.nix
+++ b/lib/tests/modules/simple-options.nix
@@ -143,4 +143,29 @@ lib.simpleOptions {
   options.OPT.options.OPT-OPT.options.OPT-OPT-LST.description = "Third level list of strings str";
   options.OPT.options.OPT-OPT.options.OPT-OPT-LST.listOf      = lib.types.str;
   options.OPT.options.OPT-OPT.options.OPT-OPT-LST.example     = [];
+
+  # Inter Type
+  options.TYP-BOO.default     = true;
+  options.TYP-BOO.description = "bool option";
+
+  options.TYP-FLT.default     =  0.0;
+  options.TYP-FLT.description = "float option";
+
+  options.TYP-INT.default     =  0;
+  options.TYP-INT.description = "int option";
+
+  options.TYP-LST.default     =  [ "TYP-LST" ];
+  options.TYP-LST.description = "list option";
+
+  options.TYP-NUL.default     =  null;
+  options.TYP-NUL.description = "null option";
+
+  options.TYP-ATT.default     =  {};
+  options.TYP-ATT.description = "attr option";
+
+  options.TYP-PKG.default     =  (import <nixpkgs> {}).emptyFile;
+  options.TYP-PKG.description = "pkg option";
+
+  options.TYP-STR.default     = "TYP-STR";
+  options.TYP-STR.description = "string option";
 }

--- a/lib/tests/modules/simple-options.nix
+++ b/lib/tests/modules/simple-options.nix
@@ -168,4 +168,8 @@ lib.simpleOptions {
 
   options.TYP-STR.default     = "TYP-STR";
   options.TYP-STR.description = "string option";
+
+  # mdDocs
+  options.TYP-DOC.default     = "TYP-DOC";
+  options.TYP-DOC.mdDoc       = "MD doc";
 }

--- a/lib/tests/modules/simple-options.nix
+++ b/lib/tests/modules/simple-options.nix
@@ -32,6 +32,11 @@ lib.simpleOptions {
   options.ATT.description = "attrset of strings";
   options.ATT.example     = {};
 
+  options.ENM.default     = "ENM";
+  options.ENM.description = "enum option example";
+  options.ENM.example     = "MNE";
+  options.ENM.enum        = [ "NME" "ENM" ];
+
   options.LST.default     = [ "LST" ];
   options.LST.description = "list of string";
   options.LST.example     = [];
@@ -48,6 +53,10 @@ lib.simpleOptions {
   options.ATT-ATT.description  = "attrset of attrset";
   options.ATT-ATT.example      = {};
 
+  options.ATT-ENM.default      = {};
+  options.ATT-ENM.description  = "attrset of enums";
+  options.ATT-ENM.example      = {};
+
   options.ATT-LST.default      = {};
   options.ATT-LST.description  = "attrset of lists";
   options.ATT-LST.example      = {};
@@ -56,6 +65,11 @@ lib.simpleOptions {
   options.ATT-ATT.attrsOf.description  = "attrset of strings";
   options.ATT-ATT.attrsOf.example      = {};
   options.ATT-ATT.attrsOf.attrsOf      = lib.types.str;
+
+  options.ATT-ENM.attrsOf.default      = "ATT-ENM";
+  options.ATT-ENM.attrsOf.description  = "attrset of strings";
+  options.ATT-ENM.attrsOf.example      = "ATT-MNE";
+  options.ATT-ENM.attrsOf.enum         = ["ATT-MNE" "ATT-ENM"];
 
   options.ATT-LST.attrsOf.default      = {};
   options.ATT-LST.attrsOf.description  = "list of strings";
@@ -77,27 +91,36 @@ lib.simpleOptions {
   options.LST-ATT.description   = "list of attrset";
   options.LST-ATT.example       = [];
 
-  options.LST-ATT.listOf.default      = [];
-  options.LST-ATT.listOf.description  = "attrset of strings";
-  options.LST-ATT.listOf.example      = [];
-  options.LST-ATT.listOf.attrsOf      = lib.types.str;
+  options.LST-ENM.default       = [];
+  options.LST-ENM.description   = "list of enum";
+  options.LST-ENM.example       = [];
 
   options.LST-LST.default       = {};
   options.LST-LST.description   = "list of lists";
   options.LST-LST.example       = {};
 
-  options.LST-LST.listOf.default      = {};
-  options.LST-LST.listOf.description  = "list of strings";
-  options.LST-LST.listOf.example      = {};
-  options.LST-LST.listOf.listOf       = lib.types.str;
-
   options.LST-OPT.default       = {};
   options.LST-OPT.description   = "list of options";
   options.LST-OPT.example       = {};
 
-  options.LST-OPT.listOf.default      = {};
-  options.LST-OPT.listOf.description  = "options with one attr";
-  options.LST-OPT.listOf.example      = {};
+  options.LST-ATT.listOf.default     = [];
+  options.LST-ATT.listOf.description = "attrset of strings";
+  options.LST-ATT.listOf.example     = [];
+  options.LST-ATT.listOf.attrsOf     = lib.types.str;
+
+  options.LST-ENM.listOf.default     = [ "LST-ENM" "LST-MNE" ];
+  options.LST-ENM.listOf.description = "list of enum";
+  options.LST-ENM.listOf.example     = [ "LST-MNE" "LST-ENM" ];
+  options.LST-ENM.listOf.enum        = [ "LST-MNE" "LST-ENM" ];
+
+  options.LST-LST.listOf.default     = [];
+  options.LST-LST.listOf.description = "list of strings";
+  options.LST-LST.listOf.example     = [];
+  options.LST-LST.listOf.listOf      = lib.types.str;
+
+  options.LST-OPT.listOf.default     = [];
+  options.LST-OPT.listOf.description = "options with one attr";
+  options.LST-OPT.listOf.example     = [];
 
   options.LST-OPT.listOf.options.LST-OPT-TYP.default     = "";
   options.LST-OPT.listOf.options.LST-OPT-TYP.description = "option of options of lists";
@@ -110,15 +133,15 @@ lib.simpleOptions {
   options.OPT.example     = {};
   options.OPT.description = "options holder";
 
-  options.OPT.options.OPT-TYP.default     = "OPT-TYP";
-  options.OPT.options.OPT-TYP.description = "second level str";
-  options.OPT.options.OPT-TYP.type        = lib.types.str;
-  options.OPT.options.OPT-TYP.example     = "some string";
-
   options.OPT.options.OPT-ATT.default     = { test = "OPT-ATT"; };
   options.OPT.options.OPT-ATT.description = "second level attrset of strings";
   options.OPT.options.OPT-ATT.attrsOf     = lib.types.str;
   options.OPT.options.OPT-ATT.example     = {};
+
+  options.OPT.options.OPT-ENM.default     = "OPT-ENM";
+  options.OPT.options.OPT-ENM.description = "second level enum";
+  options.OPT.options.OPT-ENM.enum        = [ "OTP-MNE" "OPT-ENM" ];
+  options.OPT.options.OPT-ENM.example     = "OPT-MNE";
 
   options.OPT.options.OPT-LST.default     = [ "OPT-LST" ];
   options.OPT.options.OPT-LST.description = "second level list of strings";
@@ -129,20 +152,30 @@ lib.simpleOptions {
   options.OPT.options.OPT-OPT.example     = {};
   options.OPT.options.OPT-OPT.description = "second level options holder";
 
-  options.OPT.options.OPT-OPT.options.OPT-OPT-TYP.default     = "OPT-OPT-TYP";
-  options.OPT.options.OPT-OPT.options.OPT-OPT-TYP.description = "third level str";
-  options.OPT.options.OPT-OPT.options.OPT-OPT-TYP.type        = lib.types.str;
-  options.OPT.options.OPT-OPT.options.OPT-OPT-TYP.example     = "some string";
+  options.OPT.options.OPT-TYP.default     = "OPT-TYP";
+  options.OPT.options.OPT-TYP.description = "second level str";
+  options.OPT.options.OPT-TYP.type        = lib.types.str;
+  options.OPT.options.OPT-TYP.example     = "some string";
 
   options.OPT.options.OPT-OPT.options.OPT-OPT-ATT.default     =  { test = "OPT-OPT-ATT"; };
   options.OPT.options.OPT-OPT.options.OPT-OPT-ATT.description = "Third level hasmap of strings str";
   options.OPT.options.OPT-OPT.options.OPT-OPT-ATT.attrsOf     = lib.types.str;
   options.OPT.options.OPT-OPT.options.OPT-OPT-ATT.example     = {};
 
+  options.OPT.options.OPT-OPT.options.OPT-OPT-ENM.default     = "OPT-OPT-ENM";
+  options.OPT.options.OPT-OPT.options.OPT-OPT-ENM.description = "third level str";
+  options.OPT.options.OPT-OPT.options.OPT-OPT-ENM.enum        = [ "OPT-OPT-MNE" "OPT-OPT-ENM" ];
+  options.OPT.options.OPT-OPT.options.OPT-OPT-ENM.example     = "OPT-OPT-MNE";
+
   options.OPT.options.OPT-OPT.options.OPT-OPT-LST.default     = [ "OPT-OPT-LST" ];
   options.OPT.options.OPT-OPT.options.OPT-OPT-LST.description = "Third level list of strings str";
   options.OPT.options.OPT-OPT.options.OPT-OPT-LST.listOf      = lib.types.str;
   options.OPT.options.OPT-OPT.options.OPT-OPT-LST.example     = [];
+
+  options.OPT.options.OPT-OPT.options.OPT-OPT-TYP.default     = "OPT-OPT-TYP";
+  options.OPT.options.OPT-OPT.options.OPT-OPT-TYP.description = "third level str";
+  options.OPT.options.OPT-OPT.options.OPT-OPT-TYP.type        = lib.types.str;
+  options.OPT.options.OPT-OPT.options.OPT-OPT-TYP.example     = "some string";
 
   # Inter Type
   options.TYP-BOO.default     = true;

--- a/lib/tests/modules/simple-options.nix
+++ b/lib/tests/modules/simple-options.nix
@@ -42,6 +42,11 @@ lib.simpleOptions {
   options.LST.example     = [];
   options.LST.listOf      = lib.types.str;
 
+  options.ONE.default     = "ONE";
+  options.ONE.description = "oneOf option example";
+  options.ONE.example     = "some string";
+  options.ONE.oneOf       = [ lib.types.str lib.types.int ];
+
   options.TYP.default     = "TYP";
   options.TYP.description = "string option example";
   options.TYP.example     = "some string";
@@ -61,6 +66,10 @@ lib.simpleOptions {
   options.ATT-LST.description  = "attrset of lists";
   options.ATT-LST.example      = {};
 
+  options.ATT-ONE.default      = {};
+  options.ATT-ONE.description  = "attrset of one of";
+  options.ATT-ONE.example      = {};
+
   options.ATT-ATT.attrsOf.default      = {};
   options.ATT-ATT.attrsOf.description  = "attrset of strings";
   options.ATT-ATT.attrsOf.example      = {};
@@ -75,6 +84,11 @@ lib.simpleOptions {
   options.ATT-LST.attrsOf.description  = "list of strings";
   options.ATT-LST.attrsOf.example      = {};
   options.ATT-LST.attrsOf.listOf       = lib.types.str;
+
+  options.ATT-ONE.attrsOf.default      = "ATT-ONE";
+  options.ATT-ONE.attrsOf.description  = "attrset of oneof";
+  options.ATT-ONE.attrsOf.example      = 1;
+  options.ATT-ONE.attrsOf.oneOf        = [ lib.types.str lib.types.int ];
 
   options.ATT-OPT.attrsOf.default      = {};
   options.ATT-OPT.attrsOf.description  = "options with one attr";
@@ -99,6 +113,10 @@ lib.simpleOptions {
   options.LST-LST.description   = "list of lists";
   options.LST-LST.example       = {};
 
+  options.LST-ONE.default       = [];
+  options.LST-ONE.description   = "list of one of";
+  options.LST-ONE.example       = [];
+
   options.LST-OPT.default       = {};
   options.LST-OPT.description   = "list of options";
   options.LST-OPT.example       = {};
@@ -117,6 +135,11 @@ lib.simpleOptions {
   options.LST-LST.listOf.description = "list of strings";
   options.LST-LST.listOf.example     = [];
   options.LST-LST.listOf.listOf      = lib.types.str;
+
+  options.LST-ONE.listOf.default     = [ "LST-ONE" 1 ];
+  options.LST-ONE.listOf.description = "list of one of";
+  options.LST-ONE.listOf.example     = [ 1 "LST-ONE" ];
+  options.LST-ONE.listOf.oneOf       = [ lib.types.str lib.types.int ];
 
   options.LST-OPT.listOf.default     = [];
   options.LST-OPT.listOf.description = "options with one attr";
@@ -148,6 +171,11 @@ lib.simpleOptions {
   options.OPT.options.OPT-LST.listOf      = lib.types.str;
   options.OPT.options.OPT-LST.example     = [];
 
+  options.OPT.options.OPT-ONE.default     = "OPT-ONE";
+  options.OPT.options.OPT-ONE.description = "second level one of";
+  options.OPT.options.OPT-ONE.oneOf       = [ lib.types.str lib.types.int ];
+  options.OPT.options.OPT-ONE.example     = 1;
+
   options.OPT.options.OPT-OPT.default     = {};
   options.OPT.options.OPT-OPT.example     = {};
   options.OPT.options.OPT-OPT.description = "second level options holder";
@@ -171,6 +199,11 @@ lib.simpleOptions {
   options.OPT.options.OPT-OPT.options.OPT-OPT-LST.description = "Third level list of strings str";
   options.OPT.options.OPT-OPT.options.OPT-OPT-LST.listOf      = lib.types.str;
   options.OPT.options.OPT-OPT.options.OPT-OPT-LST.example     = [];
+
+  options.OPT.options.OPT-OPT.options.OPT-OPT-ONE.default     = "OPT-OPT-ONE";
+  options.OPT.options.OPT-OPT.options.OPT-OPT-ONE.description = "third level one of";
+  options.OPT.options.OPT-OPT.options.OPT-OPT-ONE.oneOf       = [ lib.types.str lib.types.int ];
+  options.OPT.options.OPT-OPT.options.OPT-OPT-ONE.example     = 1;
 
   options.OPT.options.OPT-OPT.options.OPT-OPT-TYP.default     = "OPT-OPT-TYP";
   options.OPT.options.OPT-OPT.options.OPT-OPT-TYP.description = "third level str";

--- a/lib/tests/modules/simple-options.nix
+++ b/lib/tests/modules/simple-options.nix
@@ -211,6 +211,9 @@ lib.simpleOptions {
   options.OPT.options.OPT-OPT.options.OPT-OPT-TYP.example     = "some string";
 
   # Inter Type
+  options.TYP-ATT.default     =  {};
+  options.TYP-ATT.description = "attr option";
+
   options.TYP-BOO.default     = true;
   options.TYP-BOO.description = "bool option";
 
@@ -226,11 +229,11 @@ lib.simpleOptions {
   options.TYP-NUL.default     =  null;
   options.TYP-NUL.description = "null option";
 
-  options.TYP-ATT.default     =  {};
-  options.TYP-ATT.description = "attr option";
-
   options.TYP-PKG.default     =  (import <nixpkgs> {}).emptyFile;
   options.TYP-PKG.description = "pkg option";
+
+  options.TYP-PTH.default     =  ./.;
+  options.TYP-PTH.description = "path option";
 
   options.TYP-STR.default     = "TYP-STR";
   options.TYP-STR.description = "string option";

--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -124,7 +124,6 @@ lib.simpleOptions {
   options = {
     nix.options = {
       enable = {
-        type = types.bool;
         default = true;
         description = lib.mdDoc ''
           Whether to enable Nix.
@@ -133,7 +132,6 @@ lib.simpleOptions {
       };
 
       package = {
-        type = types.package;
         default = pkgs.nix;
         defaultText = literalExpression "pkgs.nix";
         description = lib.mdDoc ''
@@ -142,7 +140,6 @@ lib.simpleOptions {
       };
 
       distributedBuilds = {
-        type = types.bool;
         default = false;
         description = lib.mdDoc ''
           Whether to distribute builds to the machines listed in
@@ -204,7 +201,6 @@ lib.simpleOptions {
       };
 
       daemonIOSchedPriority = {
-        type = types.int;
         default = 4;
         example = 1;
         description = lib.mdDoc ''
@@ -240,7 +236,7 @@ lib.simpleOptions {
               '';
             };
             system = {
-              type = types.nullOr types.str;
+              nullOr = types.str;
               default = null;
               example = "x86_64-linux";
               description = lib.mdDoc ''
@@ -262,7 +258,7 @@ lib.simpleOptions {
               '';
             };
             sshUser = {
-              type = types.nullOr types.str;
+              nullOr = types.str;
               default = null;
               example = "builder";
               description = lib.mdDoc ''
@@ -273,7 +269,7 @@ lib.simpleOptions {
               '';
             };
             sshKey = {
-              type = types.nullOr types.str;
+              nullOr = types.str;
               default = null;
               example = "/root/.ssh/id_buildhost_builduser";
               description = lib.mdDoc ''
@@ -287,7 +283,6 @@ lib.simpleOptions {
               '';
             };
             maxJobs = {
-              type = types.int;
               default = 1;
               description = lib.mdDoc ''
                 The number of concurrent jobs the build machine supports. The
@@ -297,7 +292,6 @@ lib.simpleOptions {
               '';
             };
             speedFactor = {
-              type = types.int;
               default = 1;
               description = lib.mdDoc ''
                 The relative speed of this builder. This is an arbitrary integer
@@ -327,7 +321,7 @@ lib.simpleOptions {
               '';
             };
             publicHostKey = {
-              type = types.nullOr types.str;
+              nullOr = types.str;
               default = null;
               description = lib.mdDoc ''
                 The (base64-encoded) public host key of this builder. The field
@@ -380,7 +374,6 @@ lib.simpleOptions {
       };
 
       checkConfig = {
-        type = types.bool;
         default = true;
         description = lib.mdDoc ''
           If enabled, checks that Nix can parse the generated nix.conf.
@@ -388,7 +381,6 @@ lib.simpleOptions {
       };
 
       checkAllErrors = {
-        type = types.bool;
         default = true;
         description = lib.mdDoc ''
           If enabled, checks the nix.conf parsing for any kind of error. When disabled, checks only for unknown settings.
@@ -420,7 +412,7 @@ lib.simpleOptions {
                 description = lib.mdDoc "The flake reference {option}`from` is rewritten to.";
               };
               flake = {
-                type = types.nullOr types.attrs;
+                nullOr = types.attrs;
                 default = null;
                 example = literalExpression "nixpkgs";
                 description = lib.mdDoc ''
@@ -428,7 +420,6 @@ lib.simpleOptions {
                 '';
               };
               exact = {
-                type = types.bool;
                 default = true;
                 description = lib.mdDoc ''
                   Whether the {option}`from` reference needs to match exactly. If set,
@@ -484,7 +475,6 @@ lib.simpleOptions {
           };
 
           auto-optimise-store = {
-            type = types.bool;
             default = false;
             example = true;
             description = lib.mdDoc ''
@@ -496,7 +486,6 @@ lib.simpleOptions {
           };
 
           cores = {
-            type = types.int;
             default = 0;
             example = 64;
             description = lib.mdDoc ''
@@ -557,7 +546,6 @@ lib.simpleOptions {
           };
 
           require-sigs = {
-            type = types.bool;
             default = true;
             description = lib.mdDoc ''
               If enabled (the default), Nix will only download binaries from binary caches if

--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -125,33 +125,33 @@ lib.simpleOptions {
     nix.options = {
       enable = {
         default = true;
-        description = lib.mdDoc ''
+        mdDoc   = ''
           Whether to enable Nix.
           Disabling Nix makes the system hard to modify and the Nix programs and configuration will not be made available by NixOS itself.
         '';
       };
 
       package = {
-        default = pkgs.nix;
+        default     = pkgs.nix;
         defaultText = literalExpression "pkgs.nix";
-        description = lib.mdDoc ''
+        mdDoc       = ''
           This option specifies the Nix package instance to use throughout the system.
         '';
       };
 
       distributedBuilds = {
         default = false;
-        description = lib.mdDoc ''
+        mdDoc   = ''
           Whether to distribute builds to the machines listed in
           {option}`nix.buildMachines`.
         '';
       };
 
       daemonCPUSchedPolicy = {
-        type = types.enum [ "other" "batch" "idle" ];
+        type    = types.enum [ "other" "batch" "idle" ];
         default = "other";
         example = "batch";
-        description = lib.mdDoc ''
+        mdDoc   = ''
           Nix daemon process CPU scheduling policy. This policy propagates to
           build processes. `other` is the default scheduling
           policy for regular tasks. The `batch` policy is
@@ -181,7 +181,7 @@ lib.simpleOptions {
         type = types.enum [ "best-effort" "idle" ];
         default = "best-effort";
         example = "idle";
-        description = lib.mdDoc ''
+        mdDoc   = ''
           Nix daemon process I/O scheduling class. This class propagates to
           build processes. `best-effort` is the default
           class for regular tasks. The `idle` class is for
@@ -203,7 +203,7 @@ lib.simpleOptions {
       daemonIOSchedPriority = {
         default = 4;
         example = 1;
-        description = lib.mdDoc ''
+        mdDoc   = ''
           Nix daemon process I/O scheduling priority. This priority propagates
           to build processes. The supported priorities depend on the
           scheduling policy: With idle, priorities are not used in scheduling
@@ -216,17 +216,17 @@ lib.simpleOptions {
         listOf = {
           options = {
             hostName = {
-              type = types.str;
+              type    = types.str;
               example = "nixbuilder.example.org";
-              description = lib.mdDoc ''
+              mdDoc   = ''
                 The hostname of the build machine.
               '';
             };
             protocol = {
-              type = types.enum [ null "ssh" "ssh-ng" ];
+              type    = types.enum [ null "ssh" "ssh-ng" ];
               default = "ssh";
               example = "ssh-ng";
-              description = lib.mdDoc ''
+              mdDoc   = ''
                 The protocol used for communicating with the build machine.
                 Use `ssh-ng` if your remote builder and your
                 local Nix version support that improved protocol.
@@ -236,10 +236,10 @@ lib.simpleOptions {
               '';
             };
             system = {
-              nullOr = types.str;
+              nullOr  = types.str;
               default = null;
               example = "x86_64-linux";
-              description = lib.mdDoc ''
+              mdDoc   = ''
                 The system type the build machine can execute derivations on.
                 Either this attribute or {var}`systems` must be
                 present, where {var}`system` takes precedence if
@@ -247,10 +247,10 @@ lib.simpleOptions {
               '';
             };
             systems = {
-              type = types.listOf types.str;
+              type    = types.listOf types.str;
               default = [ ];
               example = [ "x86_64-linux" "aarch64-linux" ];
-              description = lib.mdDoc ''
+              mdDoc   = ''
                 The system types the build machine can execute derivations on.
                 Either this attribute or {var}`system` must be
                 present, where {var}`system` takes precedence if
@@ -258,10 +258,10 @@ lib.simpleOptions {
               '';
             };
             sshUser = {
-              nullOr = types.str;
+              nullOr  = types.str;
               default = null;
               example = "builder";
-              description = lib.mdDoc ''
+              mdDoc   = ''
                 The username to log in as on the remote host. This user must be
                 able to log in and run nix commands non-interactively. It must
                 also be privileged to build derivations, so must be included in
@@ -269,10 +269,10 @@ lib.simpleOptions {
               '';
             };
             sshKey = {
-              nullOr = types.str;
+              nullOr  = types.str;
               default = null;
               example = "/root/.ssh/id_buildhost_builduser";
-              description = lib.mdDoc ''
+              mdDoc   = ''
                 The path to the SSH private key with which to authenticate on
                 the build machine. The private key must not have a passphrase.
                 If null, the building user (root on NixOS machines) must have an
@@ -284,7 +284,7 @@ lib.simpleOptions {
             };
             maxJobs = {
               default = 1;
-              description = lib.mdDoc ''
+              mdDoc   = ''
                 The number of concurrent jobs the build machine supports. The
                 build machine will enforce its own limits, but this allows hydra
                 to schedule better since there is no work-stealing between build
@@ -293,17 +293,17 @@ lib.simpleOptions {
             };
             speedFactor = {
               default = 1;
-              description = lib.mdDoc ''
+              mdDoc   = ''
                 The relative speed of this builder. This is an arbitrary integer
                 that indicates the speed of this builder, relative to other
                 builders. Higher is faster.
               '';
             };
             mandatoryFeatures = {
-              type = types.listOf types.str;
+              type    = types.listOf types.str;
               default = [ ];
               example = [ "big-parallel" ];
-              description = lib.mdDoc ''
+              mdDoc   = ''
                 A list of features mandatory for this builder. The builder will
                 be ignored for derivations that don't require all features in
                 this list. All mandatory features are automatically included in
@@ -311,19 +311,19 @@ lib.simpleOptions {
               '';
             };
             supportedFeatures = {
-              type = types.listOf types.str;
+              type    = types.listOf types.str;
               default = [ ];
               example = [ "kvm" "big-parallel" ];
-              description = lib.mdDoc ''
+              mdDoc   = ''
                 A list of features supported by this builder. The builder will
                 be ignored for derivations that require features not in this
                 list.
               '';
             };
             publicHostKey = {
-              nullOr = types.str;
+              nullOr  = types.str;
               default = null;
-              description = lib.mdDoc ''
+              mdDoc   = ''
                 The (base64-encoded) public host key of this builder. The field
                 is calculated via {command}`base64 -w0 /etc/ssh/ssh_host_type_key.pub`.
                 If null, SSH will use its regular known-hosts file when connecting.
@@ -332,7 +332,7 @@ lib.simpleOptions {
           };
         };
         default = [ ];
-        description = lib.mdDoc ''
+        mdDoc   = ''
           This option lists the machines to be used if distributed builds are
           enabled (see {option}`nix.distributedBuilds`).
           Nix will perform derivations on those machines via SSH by copying the
@@ -343,15 +343,15 @@ lib.simpleOptions {
 
       # Environment variables for running Nix.
       envVars = {
-        type = types.attrs;
+        type     = types.attrs;
         internal = true;
-        default = { };
-        description = lib.mdDoc "Environment variables used by Nix.";
+        default  = { };
+        mdDoc    = "Environment variables used by Nix.";
       };
 
       nrBuildUsers = {
-        type = types.int;
-        description = lib.mdDoc ''
+        type  = types.int;
+        mdDoc = ''
           Number of `nixbld` user accounts created to
           perform secure concurrent builds.  If you receive an error
           message saying that “all build users are currently in use”,
@@ -360,13 +360,13 @@ lib.simpleOptions {
       };
 
       nixPath = {
-        type = types.listOf types.str;
+        type    = types.listOf types.str;
         default = [
           "nixpkgs=/nix/var/nix/profiles/per-user/root/channels/nixos"
           "nixos-config=/etc/nixos/configuration.nix"
           "/nix/var/nix/profiles/per-user/root/channels"
         ];
-        description = lib.mdDoc ''
+        mdDoc   = ''
           The default Nix expression search path, used by the Nix
           evaluator to look up paths enclosed in angle brackets
           (e.g. `<nixpkgs>`).
@@ -375,14 +375,14 @@ lib.simpleOptions {
 
       checkConfig = {
         default = true;
-        description = lib.mdDoc ''
+        mdDoc   = ''
           If enabled, checks that Nix can parse the generated nix.conf.
         '';
       };
 
       checkAllErrors = {
         default = true;
-        description = lib.mdDoc ''
+        mdDoc   = ''
           If enabled, checks the nix.conf parsing for any kind of error. When disabled, checks only for unknown settings.
         '';
       };
@@ -402,26 +402,26 @@ lib.simpleOptions {
           lib.simpleOptions {
             options = {
               from = {
-                type = referenceAttrs;
+                type    = referenceAttrs;
                 example = { type = "indirect"; id = "nixpkgs"; };
-                description = lib.mdDoc "The flake reference to be rewritten.";
+                mdDoc   = "The flake reference to be rewritten.";
               };
               to = {
-                type = referenceAttrs;
+                type    = referenceAttrs;
                 example = { type = "github"; owner = "my-org"; repo = "my-nixpkgs"; };
-                description = lib.mdDoc "The flake reference {option}`from` is rewritten to.";
+                mdDoc   = "The flake reference {option}`from` is rewritten to.";
               };
               flake = {
-                nullOr = types.attrs;
+                nullOr  = types.attrs;
                 default = null;
                 example = literalExpression "nixpkgs";
-                description = lib.mdDoc ''
+                mdDoc   = ''
                   The flake input {option}`from` is rewritten to.
                 '';
               };
               exact = {
                 default = true;
-                description = lib.mdDoc ''
+                mdDoc   = ''
                   Whether the {option}`from` reference needs to match exactly. If set,
                   a {option}`from` reference like `nixpkgs` does not
                   match with a reference like `nixpkgs/nixos-20.03`.
@@ -442,19 +442,19 @@ lib.simpleOptions {
           }
         );
         default = { };
-        description = lib.mdDoc ''
+        mdDoc   = ''
           A system-wide flake registry.
         '';
       };
 
       extraOptions = {
-        type = types.lines;
+        type    = types.lines;
         default = "";
         example = ''
           keep-outputs = true
           keep-derivations = true
         '';
-        description = lib.mdDoc "Additional text appended to {file}`nix.conf`.";
+        mdDoc   = "Additional text appended to {file}`nix.conf`.";
       };
 
       settings = {
@@ -462,10 +462,10 @@ lib.simpleOptions {
 
         options = {
           max-jobs = mkOption {
-            type = types.either types.int (types.enum [ "auto" ]);
+            type    = types.either types.int (types.enum [ "auto" ]);
             default = "auto";
             example = 64;
-            description = lib.mdDoc ''
+            mdDoc   = ''
               This option defines the maximum number of jobs that Nix will try to
               build in parallel. The default is auto, which means it will use all
               available logical cores. It is recommend to set it to the total
@@ -477,7 +477,7 @@ lib.simpleOptions {
           auto-optimise-store = {
             default = false;
             example = true;
-            description = lib.mdDoc ''
+            mdDoc   = ''
               If set to true, Nix automatically detects files in the store that have
               identical contents, and replaces them with hard links to a single copy.
               This saves disk space. If set to false (the default), you can still run
@@ -488,7 +488,7 @@ lib.simpleOptions {
           cores = {
             default = 0;
             example = 64;
-            description = lib.mdDoc ''
+            mdDoc   = ''
               This option defines the maximum number of concurrent tasks during
               one build. It affects, e.g., -j option for make.
               The special value 0 means that the builder should use all
@@ -499,9 +499,9 @@ lib.simpleOptions {
           };
 
           sandbox = {
-            type = types.either types.bool (types.enum [ "relaxed" ]);
+            type    = types.either types.bool (types.enum [ "relaxed" ]);
             default = true;
-            description = lib.mdDoc ''
+            mdDoc   = ''
               If set, Nix will perform builds in a sandboxed environment that it
               will set up automatically for each build. This prevents impurities
               in builds by disallowing access to dependencies outside of the Nix
@@ -514,10 +514,10 @@ lib.simpleOptions {
           };
 
           extra-sandbox-paths = {
-            listOf = types.str;
+            listOf  = types.str;
             default = [ ];
             example = [ "/dev" "/proc" ];
-            description = lib.mdDoc ''
+            mdDoc   = ''
               Directories from the host filesystem to be included
               in the sandbox.
             '';
@@ -525,7 +525,7 @@ lib.simpleOptions {
 
           substituters = {
             listOf = types.str;
-            description = lib.mdDoc ''
+            mdDoc  = ''
               List of binary cache URLs used to obtain pre-built binaries
               of Nix packages.
 
@@ -534,10 +534,10 @@ lib.simpleOptions {
           };
 
           trusted-substituters = {
-            listOf = types.str;
+            listOf  = types.str;
             default = [ ];
             example = [ "https://hydra.nixos.org/" ];
-            description = lib.mdDoc ''
+            mdDoc   = ''
               List of binary cache URLs that non-root users can use (in
               addition to those specified using
               {option}`nix.settings.substituters`) by passing
@@ -547,7 +547,7 @@ lib.simpleOptions {
 
           require-sigs = {
             default = true;
-            description = lib.mdDoc ''
+            mdDoc   = ''
               If enabled (the default), Nix will only download binaries from binary caches if
               they are cryptographically signed with any of the keys listed in
               {option}`nix.settings.trusted-public-keys`. If disabled, signatures are neither
@@ -557,9 +557,9 @@ lib.simpleOptions {
           };
 
           trusted-public-keys = {
-            listOf = types.str;
+            listOf  = types.str;
             example = [ "hydra.nixos.org-1:CNHJZBh9K4tP3EKF6FkkgeVYsS3ohTl+oS0Qa8bezVs=" ];
-            description = lib.mdDoc ''
+            mdDoc   = ''
               List of public keys used to sign binary caches. If
               {option}`nix.settings.trusted-public-keys` is enabled,
               then Nix will use a binary from a binary cache if and only
@@ -570,10 +570,10 @@ lib.simpleOptions {
           };
 
           trusted-users = {
-            listOf = types.str;
+            listOf  = types.str;
             default = [ "root" ];
             example = [ "root" "alice" "@wheel" ];
-            description = lib.mdDoc ''
+            mdDoc   = ''
               A list of names of users that have additional rights when
               connecting to the Nix daemon, such as the ability to specify
               additional binary caches, or to import unsigned NARs. You
@@ -585,9 +585,9 @@ lib.simpleOptions {
           };
 
           system-features = {
-            listOf = types.str;
+            listOf  = types.str;
             example = [ "kvm" "big-parallel" "gccarch-skylake" ];
-            description = lib.mdDoc ''
+            mdDoc   = ''
               The set of features supported by the machine. Derivations
               can express dependencies on system features through the
               `requiredSystemFeatures` attribute.
@@ -599,10 +599,10 @@ lib.simpleOptions {
           };
 
           allowed-users = {
-            listOf = types.str;
+            listOf  = types.str;
             default = [ "*" ];
             example = [ "@wheel" "@builders" "alice" "bob" ];
-            description = lib.mdDoc ''
+            mdDoc   = ''
               A list of names of users (separated by whitespace) that are
               allowed to connect to the Nix daemon. As with
               {option}`nix.settings.trusted-users`, you can specify groups by
@@ -624,7 +624,7 @@ lib.simpleOptions {
           sandbox-paths = { "/bin/sh" = "''${pkgs.busybox-sandbox-shell.out}/bin/busybox"; };
         }
       '';
-      description = lib.mdDoc ''
+      mdDoc = ''
         Configuration for Nix, see
         <https://nixos.org/manual/nix/stable/#sec-conf-file> or
         {manpage}`nix.conf(5)` for available options.

--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -148,7 +148,7 @@ lib.simpleOptions {
       };
 
       daemonCPUSchedPolicy = {
-        type    = types.enum [ "other" "batch" "idle" ];
+        enum    = [ "other" "batch" "idle" ];
         default = "other";
         example = "batch";
         mdDoc   = ''
@@ -178,7 +178,7 @@ lib.simpleOptions {
       };
 
       daemonIOSchedClass = {
-        type = types.enum [ "best-effort" "idle" ];
+        enum    = [ "best-effort" "idle" ];
         default = "best-effort";
         example = "idle";
         mdDoc   = ''
@@ -223,7 +223,7 @@ lib.simpleOptions {
               '';
             };
             protocol = {
-              type    = types.enum [ null "ssh" "ssh-ng" ];
+              enum    = [ null "ssh" "ssh-ng" ];
               default = "ssh";
               example = "ssh-ng";
               mdDoc   = ''
@@ -390,24 +390,24 @@ lib.simpleOptions {
       registry = {
         attrsOf = types.submodule (
           let
-            referenceAttrs = with types; attrsOf (oneOf [
+            referenceTypes = with types; [
               str
               int
               bool
               path
               package
-            ]);
+            ];
           in
           { config, name, ... }:
           lib.simpleOptions {
             options = {
               from = {
-                type    = referenceAttrs;
+                attrsOf.oneOf = referenceTypes;
                 example = { type = "indirect"; id = "nixpkgs"; };
                 mdDoc   = "The flake reference to be rewritten.";
               };
               to = {
-                type    = referenceAttrs;
+                attrsOf.oneOf = referenceTypes;
                 example = { type = "github"; owner = "my-org"; repo = "my-nixpkgs"; };
                 mdDoc   = "The flake reference {option}`from` is rewritten to.";
               };
@@ -462,7 +462,7 @@ lib.simpleOptions {
 
         options = {
           max-jobs = mkOption {
-            type    = types.either types.int (types.enum [ "auto" ]);
+            oneOf   = [ types.int (types.enum [ "auto" ])];
             default = "auto";
             example = 64;
             mdDoc   = ''
@@ -499,7 +499,7 @@ lib.simpleOptions {
           };
 
           sandbox = {
-            type    = types.either types.bool (types.enum [ "relaxed" ]);
+            oneOf   = [types.bool (types.enum [ "relaxed" ])];
             default = true;
             mdDoc   = ''
               If set, Nix will perform builds in a sandboxed environment that it

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -177,137 +177,137 @@ lib.simpleOptions {
   ###### interface
 
   options.systemd.options = {
-    package.default      = pkgs.systemd;
-    package.defaultText  = literalExpression "pkgs.systemd";
-    package.description  = lib.mdDoc "The systemd package.";
+    package.default     = pkgs.systemd;
+    package.defaultText = literalExpression "pkgs.systemd";
+    package.mdDoc       = "The systemd package.";
 
-    units.description    = lib.mdDoc "Definition of systemd units.";
-    units.default        = {};
-    units.type           = systemdUtils.types.units;
+    units.mdDoc         = "Definition of systemd units.";
+    units.default       = {};
+    units.type          = systemdUtils.types.units;
 
-    packages.default     = [];
-    packages.listOf      = types.package;
-    packages.example     = literalExpression "[ pkgs.systemd-cryptsetup-generator ]";
-    packages.description = lib.mdDoc "Packages providing systemd units and hooks.";
+    packages.default    = [];
+    packages.listOf     = types.package;
+    packages.example    = literalExpression "[ pkgs.systemd-cryptsetup-generator ]";
+    packages.mdDoc      =  "Packages providing systemd units and hooks.";
 
-    targets.default      = {};
-    targets.type         = systemdUtils.types.targets;
-    targets.description  = lib.mdDoc "Definition of systemd target units.";
+    targets.default     = {};
+    targets.type        = systemdUtils.types.targets;
+    targets.mdDoc       =  "Definition of systemd target units.";
 
-    services.default     = {};
-    services.type        = systemdUtils.types.services;
-    services.description = lib.mdDoc "Definition of systemd service units.";
+    services.default    = {};
+    services.type       = systemdUtils.types.services;
+    services.mdDoc      =  "Definition of systemd service units.";
 
-    sockets.default      = {};
-    sockets.type         = systemdUtils.types.sockets;
-    sockets.description  = lib.mdDoc "Definition of systemd socket units.";
+    sockets.default     = {};
+    sockets.type        = systemdUtils.types.sockets;
+    sockets.mdDoc       =  "Definition of systemd socket units.";
 
-    timers.default       = {};
-    timers.type          = systemdUtils.types.timers;
-    timers.description   = lib.mdDoc "Definition of systemd timer units.";
+    timers.default      = {};
+    timers.type         = systemdUtils.types.timers;
+    timers.mdDoc        =  "Definition of systemd timer units.";
 
-    paths.default        = {};
-    paths.type           = systemdUtils.types.paths;
-    paths.description    = lib.mdDoc "Definition of systemd path units.";
+    paths.default       = {};
+    paths.type          = systemdUtils.types.paths;
+    paths.mdDoc         =  "Definition of systemd path units.";
 
-    mounts.default       = [];
-    mounts.type          = systemdUtils.types.mounts;
-    mounts.description   = lib.mdDoc ''
+    mounts.default      = [];
+    mounts.type         = systemdUtils.types.mounts;
+    mounts.mdDoc        =  ''
       Definition of systemd mount units.
       This is a list instead of an attrSet, because systemd mandates the names to be derived from
       the 'where' attribute.
     '';
 
-    automounts.default     = [];
-    automounts.type        = systemdUtils.types.automounts;
-    automounts.description = lib.mdDoc ''
+    automounts.default = [];
+    automounts.type    = systemdUtils.types.automounts;
+    automounts.mdDoc   =  ''
       Definition of systemd automount units.
       This is a list instead of an attrSet, because systemd mandates the names to be derived from
       the 'where' attribute.
     '';
 
-    slices.default     = {};
-    slices.type        = systemdUtils.types.slices;
-    slices.description = lib.mdDoc "Definition of slice configurations.";
+    slices.default = {};
+    slices.type    = systemdUtils.types.slices;
+    slices.mdDoc   =  "Definition of slice configurations.";
 
-    generators.attrsOf     = types.path;
-    generators.default     = {};
-    generators.example     = { systemd-gpt-auto-generator = "/dev/null"; };
-    generators.description = lib.mdDoc ''
+    generators.attrsOf = types.path;
+    generators.default = {};
+    generators.example = { systemd-gpt-auto-generator = "/dev/null"; };
+    generators.mdDoc   =  ''
       Definition of systemd generators.
       For each `NAME = VALUE` pair of the attrSet, a link is generated from
       `/etc/systemd/system-generators/NAME` to `VALUE`.
     '';
 
-    shutdown.attrsOf     = types.path;
-    shutdown.default     = {};
-    shutdown.description = lib.mdDoc ''
+    shutdown.attrsOf = types.path;
+    shutdown.default = {};
+    shutdown.mdDoc   =  ''
       Definition of systemd shutdown executables.
       For each `NAME = VALUE` pair of the attrSet, a link is generated from
       `/etc/systemd/system-shutdown/NAME` to `VALUE`.
     '';
 
-    defaultUnit.default     = "multi-user.target";
-    defaultUnit.description = lib.mdDoc "Default unit started when the system boots.";
+    defaultUnit.default = "multi-user.target";
+    defaultUnit.mdDoc   =  "Default unit started when the system boots.";
 
-    ctrlAltDelUnit.default     = "reboot.target";
-    ctrlAltDelUnit.example     = "poweroff.target";
-    ctrlAltDelUnit.description = lib.mdDoc ''
+    ctrlAltDelUnit.default = "reboot.target";
+    ctrlAltDelUnit.example = "poweroff.target";
+    ctrlAltDelUnit.mdDoc   =  ''
       Target that should be started when Ctrl-Alt-Delete is pressed.
     '';
 
-    globalEnvironment.attrsOf     = with types; nullOr (oneOf [ str path package ]);
-    globalEnvironment.default     = {};
-    globalEnvironment.example     = { TZ = "CET"; };
-    globalEnvironment.description = lib.mdDoc ''
+    globalEnvironment.attrsOf = with types; nullOr (oneOf [ str path package ]);
+    globalEnvironment.default = {};
+    globalEnvironment.example = { TZ = "CET"; };
+    globalEnvironment.mdDoc   =  ''
       Environment variables passed to *all* systemd units.
     '';
 
-    managerEnvironment.attrsOf    = with types; nullOr (oneOf [ str path package ]);
-    managerEnvironment.default    = {};
-    managerEnvironment.example    = { SYSTEMD_LOG_LEVEL = "debug"; };
-    managerEnvironment.description = lib.mdDoc ''
+    managerEnvironment.attrsOf = with types; nullOr (oneOf [ str path package ]);
+    managerEnvironment.default = {};
+    managerEnvironment.example = { SYSTEMD_LOG_LEVEL = "debug"; };
+    managerEnvironment.mdDoc =  ''
       Environment variables of PID 1. These variables are
       *not* passed to started units.
     '';
 
-    enableCgroupAccounting.default     = true;
-    enableCgroupAccounting.description = lib.mdDoc ''
+    enableCgroupAccounting.default = true;
+    enableCgroupAccounting.mdDoc   =  ''
       Whether to enable cgroup accounting.
     '';
 
-    enableUnifiedCgroupHierarchy.default     = true;
-    enableUnifiedCgroupHierarchy.description = lib.mdDoc ''
+    enableUnifiedCgroupHierarchy.default = true;
+    enableUnifiedCgroupHierarchy.mdDoc   =  ''
       Whether to enable the unified cgroup hierarchy (cgroupsv2).
     '';
 
-    extraConfig.default     = "";
-    extraConfig.type        = types.lines;
-    extraConfig.example     = "DefaultLimitCORE=infinity";
-    extraConfig.description = lib.mdDoc ''
+    extraConfig.default = "";
+    extraConfig.type    = types.lines;
+    extraConfig.example = "DefaultLimitCORE=infinity";
+    extraConfig.mdDoc   =  ''
       Extra config options for systemd. See systemd-system.conf(5) man page
       for available options.
     '';
 
-    sleep.options.extraConfig.default     = "";
-    sleep.options.extraConfig.type        = types.lines;
-    sleep.options.extraConfig.example     = "HibernateDelaySec=1h";
-    sleep.options.extraConfig.description = lib.mdDoc ''
+    sleep.options.extraConfig.default = "";
+    sleep.options.extraConfig.type    = types.lines;
+    sleep.options.extraConfig.example = "HibernateDelaySec=1h";
+    sleep.options.extraConfig.mdDoc   =  ''
       Extra config options for systemd sleep state logic.
       See sleep.conf.d(5) man page for available options.
     '';
 
-    additionalUpstreamSystemUnits.default     = [ ];
-    additionalUpstreamSystemUnits.listOf      = types.str;
-    additionalUpstreamSystemUnits.example     = [ "debug-shell.service" "systemd-quotacheck.service" ];
-    additionalUpstreamSystemUnits.description = lib.mdDoc ''
+    additionalUpstreamSystemUnits.default = [ ];
+    additionalUpstreamSystemUnits.listOf  = types.str;
+    additionalUpstreamSystemUnits.example = [ "debug-shell.service" "systemd-quotacheck.service" ];
+    additionalUpstreamSystemUnits.mdDoc   =  ''
       Additional units shipped with systemd that shall be enabled.
     '';
 
-    suppressedSystemUnits.default     = [ ];
-    suppressedSystemUnits.listOf      = types.str;
-    suppressedSystemUnits.example     = [ "systemd-backlight@.service" ];
-    suppressedSystemUnits.description = lib.mdDoc ''
+    suppressedSystemUnits.default = [ ];
+    suppressedSystemUnits.listOf  = types.str;
+    suppressedSystemUnits.example = [ "systemd-backlight@.service" ];
+    suppressedSystemUnits.mdDoc   =  ''
       A list of units to skip when generating system systemd configuration directory. This has
       priority over upstream units, {option}`systemd.units`, and
       {option}`systemd.additionalUpstreamSystemUnits`. The main purpose of this is to
@@ -315,36 +315,36 @@ lib.simpleOptions {
       by other NixOS modules.
     '';
 
-    watchdog.options.device.nullOr      = types.path;
-    watchdog.options.device.default     = null;
-    watchdog.options.device.example     = "/dev/watchdog";
-    watchdog.options.device.description = lib.mdDoc ''
+    watchdog.options.device.nullOr  = types.path;
+    watchdog.options.device.default = null;
+    watchdog.options.device.example = "/dev/watchdog";
+    watchdog.options.device.mdDoc   =  ''
       The path to a hardware watchdog device which will be managed by systemd.
       If not specified, systemd will default to /dev/watchdog.
     '';
 
-    watchdog.options.runtimeTime.nullOr      = types.str;
-    watchdog.options.runtimeTime.default     = null;
-    watchdog.options.runtimeTime.example     = "30s";
-    watchdog.options.runtimeTime.description = lib.mdDoc ''
+    watchdog.options.runtimeTime.nullOr  = types.str;
+    watchdog.options.runtimeTime.default = null;
+    watchdog.options.runtimeTime.example = "30s";
+    watchdog.options.runtimeTime.mdDoc   =  ''
       The amount of time which can elapse before a watchdog hardware device
       will automatically reboot the system. Valid time units include "ms",
       "s", "min", "h", "d", and "w".
     '';
 
-    watchdog.options.rebootTime.nullOr      = types.str;
-    watchdog.options.rebootTime.default     = null;
-    watchdog.options.rebootTime.example     = "10m";
-    watchdog.options.rebootTime.description = lib.mdDoc ''
+    watchdog.options.rebootTime.nullOr  = types.str;
+    watchdog.options.rebootTime.default = null;
+    watchdog.options.rebootTime.example = "10m";
+    watchdog.options.rebootTime.mdDoc   =  ''
       The amount of time which can elapse after a reboot has been triggered
       before a watchdog hardware device will automatically reboot the system.
       Valid time units include "ms", "s", "min", "h", "d", and "w".
     '';
 
-    watchdog.options.kexecTime.nullOr        = types.str;
-    watchdog.options.kexecTime.default     = null;
-    watchdog.options.kexecTime.example     = "10m";
-    watchdog.options.kexecTime.description = lib.mdDoc ''
+    watchdog.options.kexecTime.nullOr  = types.str;
+    watchdog.options.kexecTime.default = null;
+    watchdog.options.kexecTime.example = "10m";
+    watchdog.options.kexecTime.mdDoc   =  ''
       The amount of time which can elapse when kexec is being executed before
       a watchdog hardware device will automatically reboot the system. This
       option should only be enabled if reloadTime is also enabled. Valid

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -179,7 +179,6 @@ lib.simpleOptions {
   options.systemd.options = {
     package.default      = pkgs.systemd;
     package.defaultText  = literalExpression "pkgs.systemd";
-    package.type         = types.package;
     package.description  = lib.mdDoc "The systemd package.";
 
     units.description    = lib.mdDoc "Definition of systemd units.";
@@ -231,7 +230,7 @@ lib.simpleOptions {
     slices.type        = systemdUtils.types.slices;
     slices.description = lib.mdDoc "Definition of slice configurations.";
 
-    generators.type        = types.attrsOf types.path;
+    generators.attrsOf     = types.path;
     generators.default     = {};
     generators.example     = { systemd-gpt-auto-generator = "/dev/null"; };
     generators.description = lib.mdDoc ''
@@ -249,11 +248,9 @@ lib.simpleOptions {
     '';
 
     defaultUnit.default     = "multi-user.target";
-    defaultUnit.type        = types.str;
     defaultUnit.description = lib.mdDoc "Default unit started when the system boots.";
 
     ctrlAltDelUnit.default     = "reboot.target";
-    ctrlAltDelUnit.type        = types.str;
     ctrlAltDelUnit.example     = "poweroff.target";
     ctrlAltDelUnit.description = lib.mdDoc ''
       Target that should be started when Ctrl-Alt-Delete is pressed.
@@ -275,13 +272,11 @@ lib.simpleOptions {
     '';
 
     enableCgroupAccounting.default     = true;
-    enableCgroupAccounting.type        = types.bool;
     enableCgroupAccounting.description = lib.mdDoc ''
       Whether to enable cgroup accounting.
     '';
 
     enableUnifiedCgroupHierarchy.default     = true;
-    enableUnifiedCgroupHierarchy.type        = types.bool;
     enableUnifiedCgroupHierarchy.description = lib.mdDoc ''
       Whether to enable the unified cgroup hierarchy (cgroupsv2).
     '';
@@ -320,7 +315,7 @@ lib.simpleOptions {
       by other NixOS modules.
     '';
 
-    watchdog.options.device.type        = types.nullOr types.path;
+    watchdog.options.device.nullOr      = types.path;
     watchdog.options.device.default     = null;
     watchdog.options.device.example     = "/dev/watchdog";
     watchdog.options.device.description = lib.mdDoc ''
@@ -328,7 +323,7 @@ lib.simpleOptions {
       If not specified, systemd will default to /dev/watchdog.
     '';
 
-    watchdog.options.runtimeTime.type        = types.nullOr types.str;
+    watchdog.options.runtimeTime.nullOr      = types.str;
     watchdog.options.runtimeTime.default     = null;
     watchdog.options.runtimeTime.example     = "30s";
     watchdog.options.runtimeTime.description = lib.mdDoc ''
@@ -337,7 +332,7 @@ lib.simpleOptions {
       "s", "min", "h", "d", and "w".
     '';
 
-    watchdog.options.rebootTime.type        = types.nullOr types.str;
+    watchdog.options.rebootTime.nullOr      = types.str;
     watchdog.options.rebootTime.default     = null;
     watchdog.options.rebootTime.example     = "10m";
     watchdog.options.rebootTime.description = lib.mdDoc ''
@@ -346,7 +341,7 @@ lib.simpleOptions {
       Valid time units include "ms", "s", "min", "h", "d", and "w".
     '';
 
-    watchdog.options.kexecTime.type        = types.nullOr types.str;
+    watchdog.options.kexecTime.nullOr        = types.str;
     watchdog.options.kexecTime.default     = null;
     watchdog.options.kexecTime.example     = "10m";
     watchdog.options.kexecTime.description = lib.mdDoc ''

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -256,14 +256,14 @@ lib.simpleOptions {
       Target that should be started when Ctrl-Alt-Delete is pressed.
     '';
 
-    globalEnvironment.attrsOf = with types; nullOr (oneOf [ str path package ]);
+    globalEnvironment.attrsOf.nullOr.oneOf = with types; [ str path package ];
     globalEnvironment.default = {};
     globalEnvironment.example = { TZ = "CET"; };
     globalEnvironment.mdDoc   =  ''
       Environment variables passed to *all* systemd units.
     '';
 
-    managerEnvironment.attrsOf = with types; nullOr (oneOf [ str path package ]);
+    managerEnvironment.attrsOf.nullOr.oneOf = with types; [ str path package ];
     managerEnvironment.default = {};
     managerEnvironment.example = { SYSTEMD_LOG_LEVEL = "debug"; };
     managerEnvironment.mdDoc =  ''


### PR DESCRIPTION
5 new features for nixos/nixpkgs#234990 but PR against #1 just to show the difference from current upstream PR

- nullOr attr as alias to `type = nullOr type`
- oneOf attr as alias to `type = oneOf types`
- enum attr as alias to `type = enum values`
- mdDoc attr as alias to `description = mdDoc ""`
- type inference of default value


mdDoc example:

- `DOC-EX = { mdDoc = "markdown description"; type = str; };`


nullOr example:

- `TYP-NUL.nullOr = types.str;`

enum example:

- `TYP-ENM.enum = [ "FOO" "BAR" ];`

oneOf example:

- `TYP-ONE.oneOf = [ types.str types.int ]; `

Type inference example:

- `TYP-BOO.default = true;` is bool
- `TYP-FLT.default = 0.0;` is float
- `TYP-INT.default = 0;` is int
- `TYP-PTH.default = ./.;` is path
- `TYP-STR.default = "TYP-STR";` is str
- `TYP-LST.default = [ "TYP-LST" ];` is list of anything
- `TYP-NUL.default = null;` is null or anything
- `TYP-ATT.default = {};` is attr of anything
- `TYP-PKG.default = (import <nixpkgs> {}).emptyFile;` is package
